### PR TITLE
Add CRA lint extension to show lint errors in editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009",
     "build-storybook": "build-storybook"
+  },
+  "eslintConfig": {
+    "extends": "react-app"
   }
 }


### PR DESCRIPTION
- More info in CRA docs https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#displaying-lint-output-in-the-editor

@joelhooks if you want this to, CRA requires you to globally install these packages for now:
`npm install -g eslint-config-react-app@0.2.1 eslint@3.5.0 babel-eslint@6.1.2 eslint-plugin-react@6.3.0 eslint-plugin-import@1.12.0 eslint-plugin-jsx-a11y@2.2.2 eslint-plugin-flowtype@2.18.1`
