### PR TITLE
add some instructor data 🆒

### DIFF
--- a/data/instructors/sarah-drasner/index.json
+++ b/data/instructors/sarah-drasner/index.json
@@ -1,0 +1,61 @@
+{
+  "id": 93,
+  "slug": "sarah-drasner",
+  "full_name": "Sarah Drasner",
+  "first_name": "Sarah",
+  "last_name": "Drasner",
+  "twitter": "sarah_edo",
+  "website": "http://sarahdrasnerdesign.com/",
+  "bio": "",
+  "bio_short": "I work for myself as a consultant, specializing in  architecture for Front-End component libraries, data visualizations, and SVG/SVG Animations. I teach workshops with Val Head for webanimationworkshops.com, and I'm a staff writer for CSS-Tricks.",
+  "google_plus": "",
+  "http_url": "https://egghead.io/instructors/sarah-drasner",
+  "avatar_url": "https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/093/original/hxI9M6He.jpg?1477507474",
+  "lessons_url": "https://egghead.io/api/v1/instructors/sarah-drasner/lessons",
+  "published_lessons": 0,
+  "pending_lessons": 0,
+  "reviewing_lessons": 1,
+  "revenue": {
+    "current": "oct",
+    "jan": {
+      "minutes_watched": 4234,
+      "revenue": 155.27
+    },
+    "feb": {
+      "minutes_watched": 3354,
+      "revenue": 155.92
+    },
+    "mar": {
+      "minutes_watched": 3223,
+      "revenue": 155.72
+    },
+    "apr": {
+      "minutes_watched": 3423,
+      "revenue": 155.38
+    },
+    "may": {
+      "minutes_watched": 4322,
+      "revenue": 155.62
+    },
+    "jun": {
+      "minutes_watched": 6433,
+      "revenue": 155.72
+    },
+    "jul": {
+      "minutes_watched": 4267,
+      "revenue": 155.27
+    },
+    "aug": {
+      "minutes_watched": 2433,
+      "revenue": 155.79
+    },
+    "sep": {
+      "minutes_watched": 2660,
+      "revenue": 155.43
+    },
+    "oct": {
+      "minutes_watched": 2660,
+      "revenue": 155.43
+    }
+  }
+}

--- a/data/instructors/sarah-drasner/lessons/index.json
+++ b/data/instructors/sarah-drasner/lessons/index.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": 1484,
+    "slug": "angular-1-x-svg-dom-basics-circles-and-rects",
+    "title": "SVG DOM Basics: Circles and Rects",
+    "state": "reviewing",
+    "summary": "Introduction to the SVG DOM, starting with circles, ellipses and rectangles",
+    "duration": 104,
+    "old_technology": "Angular 1.x",
+    "plays_count": 0,
+    "published_at": null,
+    "is_pro_content": false,
+    "difficulty_rating": 0,
+    "tag_list": [
+      "free",
+      "angular 1.x"
+    ],
+    "library_list": [],
+    "language_list": [],
+    "framework_list": [],
+    "tool_list": [],
+    "platform_list": [],
+    "skillset_list": [],
+    "skill_level_list": [],
+    "lesson_url": "https://egghead.io/api/v1/lessons/angular-1-x-svg-dom-basics-circles-and-rects",
+    "lesson_http_url": "https://egghead.io/lessons/angular-1-x-svg-dom-basics-circles-and-rects",
+    "icon_url": "//d1xwtr0qwr70yv.cloudfront.net/assets/tech/angularjs-c68b3301858113bb00ee792cf62cc36f.svg",
+    "thumb_nail": "https://dcv19h61vib2d.cloudfront.net/thumbs/egghead-svg-dom-basics-circles-and-rects/egghead-svg-dom-basics-circles-and-rects.jpg",
+    "related_url": "https://egghead.io/api/v1/lessons/1484/related",
+    "is_pro": false,
+    "technology": {
+      "name": "angularjs",
+      "label": "Angular 1.x",
+      "http_url": "https://egghead.io/technologies/angularjs",
+      "logo_http_url": "//d1xwtr0qwr70yv.cloudfront.net/assets/tech/angularjs-c68b3301858113bb00ee792cf62cc36f.svg"
+    },
+    "instructor": {
+      "id": 93,
+      "slug": "sarah-drasner",
+      "full_name": "Sarah Drasner",
+      "first_name": "Sarah",
+      "last_name": "Drasner",
+      "twitter": "sarah_edo",
+      "website": "http://sarahdrasnerdesign.com/",
+      "bio": "",
+      "bio_short": "I work for myself as a consultant, specializing in  architecture for Front-End component libraries, data visualizations, and SVG/SVG Animations. I teach workshops with Val Head for webanimationworkshops.com, and I'm a staff writer for CSS-Tricks.",
+      "google_plus": "",
+      "http_url": "https://egghead.io/instructors/sarah-drasner",
+      "avatar_url": "https://d2eip9sf3oo6c2.cloudfront.net/instructors/avatars/000/000/093/original/hxI9M6He.jpg?1477507474",
+      "lessons_url": "https://egghead.io/api/v1/instructors/sarah-drasner/lessons",
+      "published_lessons": 0,
+      "pending_lessons": 0,
+      "reviewing_lessons": 1,
+      "revenue": {
+        "current": "oct",
+        "jan": {
+          "minutes_watched": 4234,
+          "revenue": 155.27
+        },
+        "feb": {
+          "minutes_watched": 3354,
+          "revenue": 155.92
+        },
+        "mar": {
+          "minutes_watched": 3223,
+          "revenue": 155.72
+        },
+        "apr": {
+          "minutes_watched": 3423,
+          "revenue": 155.38
+        },
+        "may": {
+          "minutes_watched": 4322,
+          "revenue": 155.62
+        },
+        "jun": {
+          "minutes_watched": 6433,
+          "revenue": 155.72
+        },
+        "jul": {
+          "minutes_watched": 4267,
+          "revenue": 155.27
+        },
+        "aug": {
+          "minutes_watched": 2433,
+          "revenue": 155.79
+        },
+        "sep": {
+          "minutes_watched": 2660,
+          "revenue": 155.43
+        },
+        "oct": {
+          "minutes_watched": 2660,
+          "revenue": 155.43
+        }
+      }
+    },
+    "download_url": "https://d3j4ov1z2pxjvg.cloudfront.net/lessons/egghead-svg-dom-basics-circles-and-rects/egghead-svg-dom-basics-circles-and-rects.mp4?Expires=1477680093&Signature=Qj6GEZtB~AgLxWxxmAHuJH72MNjeVmxpQjIAIWoF8A-UjqrykWIOqtTp89DeYU3BGUkr~R29WWP7ccZqcg~MVCTh1OeH1gSqlnA4n7lFxh-VlhypCxZgLsd9RkQ54T5WxcjfmfohwDmhzmPUmtnwZdqUvBX49AQUMCBxcSpixW8V9go~bdO2SfWK~8Kme8mfEcu~ngS5dTNCGkuuBSlAHRkzoIp~d98oWsNgB8X8kLk7bBL4c~gFLjDoEFEkEMGDhHIX01vYVAuvSiApYy~UN4O~EPcvpsPJR~G8Hb81~~Uo1MeLhQo7FjvofhhmBtVsSjLuz5ASQ2RCP5LyDBNZRQ__&Key-Pair-Id=APKAIEGNPCBY26T6OCUQ",
+    "wistia_id": "qgzeprepat",
+    "approve_url": "/lessons/1484/approve",
+    "reject_url": "/lessons/1484/reject",
+    "completed": false,
+    "view": {},
+    "new_view_url": "https://egghead.io/api/v1/lessons/angular-1-x-svg-dom-basics-circles-and-rects/views/new"
+  }
+]


### PR DESCRIPTION
Just added Sarah for now. Not stoked about how the instructor is inlined with the lesson and think it should have an `instructor_url` prop, but that would affect other systems to remove right now so requires some investigation...

I can add more to this. I put it in the folder structure that I prefer, but happy to make alterations. Typically I will dynamically change URLs so that the api endpoints are converted to local dev scheme instead of pointing to prod. [Here's an example of that in a rudimentary way](https://github.com/joelhooks/egghead-workshop-0916c/blob/master/project-seed/server/server.js#L32).

(fyi, company policy requires gifs in all PRs...)

![](https://media.giphy.com/media/msKNSs8rmJ5m/giphy.gif)
