### PR TITLE
Finish GetPublished step logic with new instructor properties

### DIFF
--- a/.fakeApi/index.js
+++ b/.fakeApi/index.js
@@ -36,11 +36,14 @@ module.exports = () => {
         full_name: fullName,
         first_name: head(split(fullName, ' ')),
         lessons_url: `localhost:4000/api/v1/instructors/${id}/lessons`,
-
-        // UNIMPLEMENTED
-        is_published: has(overrides, 'isInstructorPublished')
-          ? overrides.isInstructorPublished
-          : faker.random.boolean(),
+        slack_id: faker.random.arrayElement([null, faker.internet.userName()]),
+        gear_tracking_id: faker.random.arrayElement([null, faker.random.uuid()]),
+        published_lessons: has(overrides, 'publishedLessons')
+          ? overrides.publishedLessons
+          : faker.random.number({
+              min: 0,
+              max: 200,
+            }),
       }
     }),
 

--- a/.fakeApi/overrides.js
+++ b/.fakeApi/overrides.js
@@ -1,7 +1,7 @@
 /**
  * OPTIONS:
+ * publishedLessons: number
  */
 
 module.exports = {
-  isInstructorPublished: false,
 }

--- a/src/App/screens/Instructor/screens/GetPublished/components/GetPublishedSteps/index.js
+++ b/src/App/screens/Instructor/screens/GetPublished/components/GetPublishedSteps/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import map from 'lodash/map'
 import uniq from 'lodash/uniq'
 import compact from 'lodash/uniq'
+import isString from 'lodash/isString'
 import isStepComplete from './utils/isStepComplete'
 import Checklist from './components/Checklist'
 import DescriptionBlock from './components/DescriptionBlock'
@@ -13,13 +14,14 @@ const GetPublishedSteps = ({
 
   const instructorLessonStates = compact(uniq(map(instructorLessons.lessons, 'state')))
 
+  console.log(instructor)
   const steps = [
     {
       isComplete: true,
       description: 'Create an instructor account',
     },
     {
-      isComplete: true,
+      isComplete: isString(instructor.slack_id),
       description: 'Join egghead Slack',
       moreInfoUrl: 'https://instructor.egghead.io/01-invited/invited.html',
     },
@@ -29,7 +31,7 @@ const GetPublishedSteps = ({
       moreInfoUrl: 'https://instructor.egghead.io/01-invited/first-lesson.html',
     },
     {
-      isComplete: true,
+      isComplete: isString(instructor.gear_tracking_id),
       description: 'Get gear',
       moreInfoUrl: 'https://instructor.egghead.io/02-creating-lessons/recording-gear.html',
     },


### PR DESCRIPTION
# Changes

- Add final GetPublished step logic for slack and gear tracking
- Update fakeApi results to match

# Result For User

Each item checks off as the related state is completed on the server:

![screen shot 2016-11-03 at 2 53 41 pm](https://cloud.githubusercontent.com/assets/5497885/19985049/7a0c05d2-a1d6-11e6-9fb9-0866bbab5430.png)

![screen shot 2016-11-03 at 2 55 49 pm](https://cloud.githubusercontent.com/assets/5497885/19985051/7a1daf12-a1d6-11e6-9c4e-d67273b6f65a.png)

Once at least one lesson has been published, the default instructor route becomes the "Overview" instead of "GetPublished":

![screen shot 2016-11-03 at 2 56 32 pm](https://cloud.githubusercontent.com/assets/5497885/19985050/7a1ad9b8-a1d6-11e6-8867-2538bf433a4a.png)

![](http://i.giphy.com/A0f5wtWKhErao.gif)