### PR TITLE
Generic components

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -2,7 +2,7 @@ import {configure} from '@kadira/storybook'
 import 'font-awesome/css/font-awesome.min.css'
 import 'tachyons'
 
-const req = require.context('../src/App/components', true, /.guide.js$/)
+const req = require.context('../src/App/', true, /.guide.js$/)
 
 function loadStories() {
   req.keys().forEach((filename) => req(filename))

--- a/README.md
+++ b/README.md
@@ -71,14 +71,6 @@ When running the app in the "fake" environment, the `.fakeApi` directory holds c
 
 ## Source Directory (`src/`)
 
-### Styles
-
-Styling is done with default Tachyons classes. The `*-ns` (not small) classes are used to apply anything specific to non-mobile screen sizes, so that all components are built mobile-first.
-
-### Unit Tests
-
-Modules and components that could benefit from unit tests have an `index.test.js` file next to them.
-
 ### Components
 
 Each directory inside `src` is a **component**.
@@ -123,6 +115,15 @@ The *root screen* is the container for the entire app. It has everything a scree
 
 - `index.js` wires up the component and state trees.
 - `state/` wires up all sub-screen `reducers/` and `epics/`.
-- `components/` contains *general* components that have been promoted all the way to the top. Once promoted to the top, these general components get two additional files:
-  - `index.guide.js`: appends instances of the component to the living style guide.
-  - `index.test.js`: adds snapshot tests for instances of the component.
+
+### Style Guide
+
+Components that could benefit from being a part of the living style guide have an `index.guide.js` file next to them. This means they are automatically added to the living style guide.
+
+### Styles
+
+Styling is done with default Tachyons classes. The `*-ns` (not small) classes are used to apply anything specific to non-mobile screen sizes, so that all components are built mobile-first.
+
+### Tests
+
+Modules and components that could benefit from tests have an `index.test.js` file next to them. These are generally simple unit or snapshot tests where they provide value.

--- a/src/App/index.test.js
+++ b/src/App/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import App from './index'
+import App from '.'
 
 test('App renders without crashing', () => {
   const div = document.createElement('div')

--- a/src/App/screens/Instructor/components/GuideVariation.js
+++ b/src/App/screens/Instructor/components/GuideVariation.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const GuideVariation = ({tooltip, children}) => (
+  <div title={tooltip}>
+    {children}
+  </div>
+)
+
+GuideVariation.propTypes = {
+  tooltip: React.PropTypes.string.isRequired,
+  children: React.PropTypes.node.isRequired,
+}
+
+export default GuideVariation
+

--- a/src/App/screens/Instructor/components/Icon/__snapshots__/index.test.js.snap
+++ b/src/App/screens/Instructor/components/Icon/__snapshots__/index.test.js.snap
@@ -1,0 +1,19 @@
+exports[`test sizes 1`] = `
+<span
+  className="
+    fa
+    fa-info-circle 
+    fa-2x
+    
+  " />
+`;
+
+exports[`test types 1`] = `
+<span
+  className="
+    fa
+    fa-info-circle 
+    
+    
+  " />
+`;

--- a/src/App/screens/Instructor/components/Icon/index.guide.js
+++ b/src/App/screens/Instructor/components/Icon/index.guide.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import map from 'lodash/map'
+import keys from 'lodash/keys'
+import {storiesOf} from '@kadira/storybook'
+import GuideVariation from '../GuideVariation'
+import Icon, {sizes, types} from './index'
+
+storiesOf('Icon', module)
+
+  .add('default', () => (
+    <Icon type='more-info' />
+  ))
+
+  .add('sizes', () => (
+    <div>
+      {map(keys(sizes), size => (
+        <GuideVariation tooltip={size}>
+          <Icon
+            type='more-info'
+            size={size}
+          />
+        </GuideVariation>
+      ))}
+    </div>
+  ))
+
+  .add('types', () => (
+    <div>
+      {map(keys(types), type => (
+        <GuideVariation tooltip={type}>
+          <Icon type={type} />
+        </GuideVariation>
+      ))}
+    </div>
+  ))

--- a/src/App/screens/Instructor/components/Icon/index.js
+++ b/src/App/screens/Instructor/components/Icon/index.js
@@ -1,0 +1,39 @@
+import React from 'react'
+
+export const sizes = {
+  1: '',
+  2: 'fa-lg',
+  3: 'fa-2x',
+  4: 'fa-3x',
+  5: 'fa-4x',
+  6: 'fa-5x',
+}
+
+export const types = {
+  'menu': 'bars',
+  'step-incomplete': 'square-o',
+  'step-complete': 'check-square-o',
+  'close': 'close',
+  'more-info': 'info-circle',
+}
+
+const Icon = ({
+  type,
+  size = 1,
+  className = '',
+}) => (
+  <span className={`
+    fa
+    fa-${types[type]} 
+    ${sizes[size]}
+    ${className}
+  `} />
+)
+
+Icon.propTypes = {
+  type: React.PropTypes.oneOf(Object.keys(types)).isRequired,
+  size: React.PropTypes.oneOf(Object.keys(sizes)),
+  className:  React.PropTypes.string,
+}
+
+export default Icon

--- a/src/App/screens/Instructor/components/Icon/index.test.js
+++ b/src/App/screens/Instructor/components/Icon/index.test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import Icon from '.'
+
+test('types', () => {
+  const tree = renderer.create(
+    <Icon type='more-info' />
+  )
+  expect(tree).toMatchSnapshot()
+})
+
+test('sizes', () => {
+  const tree = renderer.create(
+    <Icon
+      type='more-info'
+      size='3'
+    />
+  )
+  expect(tree).toMatchSnapshot()
+})

--- a/src/App/screens/Instructor/components/Logo/__snapshots__/index.test.js.snap
+++ b/src/App/screens/Instructor/components/Logo/__snapshots__/index.test.js.snap
@@ -1,4 +1,4 @@
-exports[`test Default 1`] = `
+exports[`test default 1`] = `
 <img
   alt="egghead.io logo"
   src="test-file-stub" />

--- a/src/App/screens/Instructor/components/Logo/index.guide.js
+++ b/src/App/screens/Instructor/components/Logo/index.guide.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import {storiesOf} from '@kadira/storybook'
-import Logo from './index'
+import Logo from '.'
 
 storiesOf('Logo', module)
-  .add('Default', () => (
+  .add('default', () => (
     <Logo />
   ))

--- a/src/App/screens/Instructor/components/Logo/index.test.js
+++ b/src/App/screens/Instructor/components/Logo/index.test.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import Logo from './index'
+import Logo from '.'
 
-test('Default', () => {
+test('default', () => {
   const tree = renderer.create(
     <Logo />
   )

--- a/src/App/screens/Instructor/components/Nav/index.js
+++ b/src/App/screens/Instructor/components/Nav/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'react-router/Link'
+import Icon from '../Icon'
 import Logo from '../Logo'
 import NavLink from './components/NavLink'
 
@@ -64,14 +65,18 @@ class Nav extends React.Component {
             onClick={this.toggle.bind(this)}
             className='absolute top-0 right-1 dn-ns'
           >
-            <span className={`
-              white
-              fa fa-2x
-              ${this.state.isOpen
-                ? 'fa-close'
-                : 'fa-bars'
-              }`
-            } />
+            {this.state.isOpen
+              ? <Icon
+                  type='close'
+                  size='3'
+                  className='white'
+                />
+              : <Icon
+                  type='menu'
+                  size='3'
+                  className='white'
+                />
+            }
           </div>
 
         </div>

--- a/src/App/screens/Instructor/screens/GetPublished/components/GetPublishedSteps/components/Checklist.js
+++ b/src/App/screens/Instructor/screens/GetPublished/components/GetPublishedSteps/components/Checklist.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Icon from '../../../../../components/Icon'
 import MoreInfo from '../../MoreInfo'
 
 const Checklist = ({items}) => (
@@ -10,8 +11,16 @@ const Checklist = ({items}) => (
       >
         <div className='mr2'>
           {item.isComplete
-            ? <span className='fa fa-check-square-o fa-lg gray' />
-            : <span className='fa fa-square-o fa-lg green' />
+            ? <Icon
+                type='step-complete'
+                size='2'
+                className='gray'
+              />
+            : <Icon
+                type='step-incomplete'
+                size='2'
+                className='green'
+              />
           }
         </div>
         <div>

--- a/src/App/screens/Instructor/screens/GetPublished/components/MoreInfo.js
+++ b/src/App/screens/Instructor/screens/GetPublished/components/MoreInfo.js
@@ -1,9 +1,10 @@
 import React from 'react'
+import Icon from '../../../components/Icon'
 import Anchor from './Anchor'
 
 const MoreInfo = ({url}) => (
   <Anchor url={url}>
-    <span className='fa fa-info-circle' />
+    <Icon type='more-info' />
   </Anchor>
 )
 


### PR DESCRIPTION
# Changes

- Update storybook config to allow `.guide.js` files in any component directory; since we aren't building other roles right now components wont get promoted to the top for a while but some components are generic enough that I'd like to add snapshot tests and storybook stories for them.
- Update README to match
- Add `.guide.js` and `.test.js` for `Icon` and `Logo` components
- Add `GuideVariations` component to create sub-variations of a storybook story with hover tooltips.

# Result For User

The living style guide:

![style-guide](https://cloud.githubusercontent.com/assets/5497885/20022957/9992f6be-a2a2-11e6-9c64-98a499387c8b.gif)

Tests:

![image](https://cloud.githubusercontent.com/assets/5497885/20022866/32669310-a2a2-11e6-9f83-526690bb28f2.png)

---

![](http://i.giphy.com/vN3fMMSAmVwoo.gif)