### PR TITLE
Prepare project for CI runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 coverage
 
 # production
+storybook-static/
 build
 
 # misc

--- a/README.md
+++ b/README.md
@@ -130,3 +130,11 @@ The `SnapshotFixtures` file provides **static** fixtures that can be used for th
 Components that could benefit from being a part of the living style guide have an `index.guide.js` file next to them. This means they are automatically added to the living style guide.
 The `faker` package provides **random** fixtures that can be used for the props of the components of guide files.
 The `GuideVariations` component can be used to render variations of a component.
+
+---
+
+# Pull Requests & Continuous Integration
+
+The `master` branch is _protected_. It requires new code be submitted as pull requests and that Continuous Integration through [Codeship](https://app.codeship.com/projects/183842) passes before the pull request can be merged.
+
+Continuous Integration runs the `yarn verify` script, which sets the `CI` variable (so that processes only run once, instead of in watch mode) and then checks that tests and builds execute without errors.

--- a/package.json
+++ b/package.json
@@ -8,13 +8,17 @@
     "test": "react-scripts test --env=jsdom",
     "build": "npm-run-all build:**",
     "build:guide": "build-storybook",
-    "build:app": "react-scripts build"
+    "build:app": "react-scripts build",
+    "verify": "CI=true yarn test && yarn build:guide && yarn build:app"
   },
   "eslintConfig": {
     "extends": "react-app"
   },
   "homepage": ".",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "private": true,
   "devDependencies": {
     "@kadira/storybook": "^2.5.2",

--- a/src/App/index.test.js
+++ b/src/App/index.test.js
@@ -1,8 +1,0 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import App from '.'
-
-test('App renders without crashing', () => {
-  const div = document.createElement('div')
-  ReactDOM.render(<App />, div)
-})


### PR DESCRIPTION
# Changes

- Add node version in package.json `engines` for CI and other tools to know what node versions are supported.
- Add `verify` script for CI to run; it ensures tests and builds execute without errors.
- Update `README` with PR and CI info.
- Update `.gitignore` with built living style guide dir.
- Remove `App renders without crashing` test. Currently, [jsdom has issues with React Router](https://github.com/tmpvar/jsdom/issues/1378). There are workarounds, but I would prefer to add separate integration tests later using a real DOM and check that each route renders without errors.  The issues this test was catching before are already being caught by the `build` scripts for compile errors. For runtime errors, I see more value in a separate set of integration tests rather than mocking the DOM.
- Add project to `Codeship` (uses cached `yarn` and `yarn verify` script).
- Add protected `master` branch in GitHub (requires CI pass before merge, and merging to master only by admins).

# Result For User

![screen shot 2016-11-08 at 11 41 25 am](https://cloud.githubusercontent.com/assets/5497885/20112427/915efa38-a5a9-11e6-8540-eaf5fa868d2c.png)

![screen shot 2016-11-08 at 11 40 15 am](https://cloud.githubusercontent.com/assets/5497885/20112426/915d1c86-a5a9-11e6-9164-ecf320dbc159.png)

![image](https://cloud.githubusercontent.com/assets/5497885/20113875/7d97139a-a5af-11e6-9f5f-bed7e053e984.png)

![screen shot 2016-11-08 at 11 53 43 am](https://cloud.githubusercontent.com/assets/5497885/20112552/0eabb4ae-a5aa-11e6-8406-a1ebf44cd64b.png)

---

![](http://i.giphy.com/jBLJuTezU5tra.gif)