### PR TITLE
Allow json-server API params when running in FAKE environment

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -1,4 +1,5 @@
 # FAKE
+REACT_APP_FAKE_API=true
 REACT_APP_EGGHEAD_BASE_URL=http://localhost:4000/api/v1
 REACT_APP_EGGHEAD_JWT=null
 

--- a/.fakeApi/index.js
+++ b/.fakeApi/index.js
@@ -19,10 +19,18 @@ module.exports = () => {
   })
 
   const lessonStates = [
+    'proposed',
+    'cancelled',
+    'accepted',
+    'claimed',
     'submitted',
+    'rejected',
     'updated',
     'approved',
     'published',
+    'flagged',
+    'revised',
+    'retired',
   ]
 
   return {

--- a/src/App/screens/Instructor/screens/InstructorOverview/index.js
+++ b/src/App/screens/Instructor/screens/InstructorOverview/index.js
@@ -14,9 +14,8 @@ class InstructorOverview extends React.Component {
     requestInstructorLessons({
       lessons_url: instructor.lessons_url,
       page: currentPage,
-      size: 10
+      size: 10,
     })
-
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/App/screens/Instructor/state/epics/fetchLessonsForInstructor.js
+++ b/src/App/screens/Instructor/state/epics/fetchLessonsForInstructor.js
@@ -14,7 +14,16 @@ function handleLessonsResponse(response) {
 
 // I couldn't figure out how to get the Rx ajax operator to give me the headers so I just used fetch...
 function fetchLessons(lessonPage) {
-  const url = `${lessonPage.lessons_url}?page=${lessonPage.page}&size=${lessonPage.size}`
+  const paramNamesByEnv = process.env.REACT_APP_FAKE_API
+    ? {
+        page: '_page',
+        size: '_limit',
+      }
+    : {
+        page: 'page',
+        size: 'size',
+      }
+  const url = `${lessonPage.lessons_url}?${paramNamesByEnv.page}=${lessonPage.page}&${paramNamesByEnv.size}=${lessonPage.size}`
   return Observable.fromPromise(
     fetch(url, {headers})
       .then(handleLessonsResponse))


### PR DESCRIPTION
# Changes

- Add logic for switching param key  names if using json-server (FAKE API env)

# Result For User

No visual changes

---

![](https://media.giphy.com/media/dcubXtnbck0RG/giphy.gif)