### PR TITLE
Update lesson state logic

### DIFF
--- a/src/App/screens/Instructor/screens/LessonTopics/index.js
+++ b/src/App/screens/Instructor/screens/LessonTopics/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Split from '../../../../components/Split'
-import {lessonTopicsLessonStates} from '../../utils/lessonStatesGroups'
+import {unclaimedLessonTopicsLessonStates} from '../../utils/lessonStatesGroups'
 import LessonsByPage from '../../components/LessonsByPage'
 import Unclaimed from './components/Unclaimed'
 
@@ -8,7 +8,7 @@ export default ({
   instructor,
   allLessons,
 }) => (
-  <LessonsByPage states={lessonTopicsLessonStates}>
+  <LessonsByPage states={unclaimedLessonTopicsLessonStates}>
     {({currentPage, fetchLessons, pageSize}) => (
       <Split
         title='Lesson Topics'

--- a/src/App/screens/Instructor/utils/lessonStatesGroups/index.js
+++ b/src/App/screens/Instructor/utils/lessonStatesGroups/index.js
@@ -1,8 +1,21 @@
 import lessonStates from '../lessonStates'
 import {slice, indexOf} from 'lodash'
 
-export const inProgressLessonStates = slice(lessonStates, 0, indexOf(lessonStates, 'published'))
+export const lessonTopicsLessonStates = slice(
+  lessonStates, 
+  0,
+  indexOf(lessonStates, 'submitted')
+)
 
-export const lessonTopicsLessonStates = slice(lessonStates, 0, indexOf(lessonStates, 'submitted'))
+export const unclaimedLessonTopicsLessonStates = ['accepted']
 
-export const publishedLessonStates = slice(lessonStates, indexOf(lessonStates, 'published'))
+export const inProgressLessonStates = slice(
+  lessonStates,
+  indexOf(lessonStates, 'claimed'),
+  indexOf(lessonStates, 'published')
+)
+
+export const publishedLessonStates = slice(
+  lessonStates,
+  indexOf(lessonStates, 'published')
+)

--- a/src/App/screens/Instructor/utils/lessonStatesGroups/index.test.js
+++ b/src/App/screens/Instructor/utils/lessonStatesGroups/index.test.js
@@ -1,21 +1,9 @@
 import {
   lessonTopicsLessonStates,
+  unclaimedLessonTopicsLessonStates,
   inProgressLessonStates,
   publishedLessonStates,
 } from '.'
-
-test('in progress', () => (
-  expect(inProgressLessonStates).toEqual([
-    'proposed',
-    'cancelled',
-    'accepted',
-    'claimed',
-    'submitted',
-    'rejected',
-    'updated',
-    'approved',
-  ])
-))
 
 test('lesson topics', () => (
   expect(lessonTopicsLessonStates).toEqual([
@@ -23,6 +11,22 @@ test('lesson topics', () => (
     'cancelled',
     'accepted',
     'claimed',
+  ])
+))
+
+test('unclaimed lesson topics', () => (
+  expect(unclaimedLessonTopicsLessonStates).toEqual([
+    'accepted',
+  ])
+))
+
+test('in progress', () => (
+  expect(inProgressLessonStates).toEqual([
+    'claimed',
+    'submitted',
+    'rejected',
+    'updated',
+    'approved',
   ])
 ))
 


### PR DESCRIPTION
# Changes

- Unclaimed lesson topics are only those in the `accepted` state

# Result For User

## "In Progress" view shows `claimed` through `approved`

![image](https://cloud.githubusercontent.com/assets/5497885/20497186/77d714ce-afe5-11e6-81aa-e072ff2a6fa1.png)

## "Lesson Topics" view shows `accepted`

![image](https://cloud.githubusercontent.com/assets/5497885/20497221/9bc16e20-afe5-11e6-86de-cc612275b978.png)

## "Published Lessons" view shows `published` through `retired`

![image](https://cloud.githubusercontent.com/assets/5497885/20497236/aa9ddaf0-afe5-11e6-82ee-8db02544f042.png)

---

![](https://media.giphy.com/media/ND6xkVPaj8tHO/giphy.gif)