### PR TITLE
Add conditional rendering for missing API pieces

### DIFF
--- a/.fakeApi/index.js
+++ b/.fakeApi/index.js
@@ -89,7 +89,6 @@ module.exports = () => {
               max: 70,
             }),
         revenue: {
-          total: revenueFactory(1000000, 100000),
           current: 'mar',
           jan: revenueFactory(),
           feb: revenueFactory(),

--- a/src/App/screens/Instructor/screens/Overview/components/Stats/index.js
+++ b/src/App/screens/Instructor/screens/Overview/components/Stats/index.js
@@ -32,21 +32,24 @@ export default ({instructor}) => {
                 <RevenueIconLabel amount={currentRevenue.revenue} />
               </div>
 
-              <div>
-                <Heading level='3'>
-                  Total
-                </Heading>
-                <IconLabel
-                  iconType='course'
-                  labelText={`${formatNumber()(published_courses)} published courses`}
-                />
-                <IconLabel
-                  iconType='lesson'
-                  labelText={`${formatNumber()(published_lessons)} published lessons`}
-                />
-                <SubscriberMinutesIconLabel amount={totalRevenue.minutes_watched} />
-                <RevenueIconLabel amount={totalRevenue.revenue} />
-              </div>
+              {totalRevenue
+                ? <div>
+                    <Heading level='3'>
+                      Total
+                    </Heading>
+                    <IconLabel
+                      iconType='course'
+                      labelText={`${formatNumber()(published_courses)} published courses`}
+                    />
+                    <IconLabel
+                      iconType='lesson'
+                      labelText={`${formatNumber()(published_lessons)} published lessons`}
+                    />
+                    <SubscriberMinutesIconLabel amount={totalRevenue.minutes_watched} />
+                    <RevenueIconLabel amount={totalRevenue.revenue} />
+                  </div>
+                : null
+              }
 
             </div>
 


### PR DESCRIPTION
# Changes

- Make `revenue.total` rendering conditional for now until API is updated; will be moving to a URL based fetch as well for revenue but keeping as is for now so at least the current month stats show.

# Result For User

No more total, for now:

![screen shot 2016-12-16 at 3 42 56 pm](https://cloud.githubusercontent.com/assets/5497885/21281241/59aaf7dc-c3a8-11e6-9afd-c6bfbdfc2eae.png)

---

![](https://media.giphy.com/media/l2YWtYxKrvgV1Yb16/giphy.gif)