### PR TITLE
Add loading spinners

### DIFF
--- a/src/App/screens/Instructor/components/Icon/index.js
+++ b/src/App/screens/Instructor/components/Icon/index.js
@@ -22,11 +22,13 @@ export const types = {
   'revenue': 'money',
   'course': 'folder-open-o',
   'lesson': 'file-o',
+  'refresh': 'refresh',
 }
 
 const Icon = ({
   type,
   size = '1',
+  spin = false,
   className = '',
 }) => (
   <span className={`
@@ -34,12 +36,14 @@ const Icon = ({
     fa-${types[type]} 
     ${sizes[size]}
     ${className}
+    ${spin ? 'fa-spin' : ''}
   `} />
 )
 
 Icon.propTypes = {
   type: PropTypes.oneOf(keys(types)).isRequired,
   size: PropTypes.oneOf(keys(sizes)),
+  spin: PropTypes.bool,
   className:  PropTypes.string,
 }
 

--- a/src/App/screens/Instructor/components/LessonsByPage/index.js
+++ b/src/App/screens/Instructor/components/LessonsByPage/index.js
@@ -19,7 +19,7 @@ export default connect(
   }
 
   state = {
-    isLoading: true,
+    isLoading: false,
     currentPage: 1,
   }
 

--- a/src/App/screens/Instructor/components/LessonsByPage/index.js
+++ b/src/App/screens/Instructor/components/LessonsByPage/index.js
@@ -1,9 +1,12 @@
-import {Component, PropTypes} from 'react'
+import React, {Component, PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {startFetchInstructorLessons, startFetchAllLessons} from '../../state/actions'
+import Loading from '../Loading'
 
 export default connect(
-  null,
+  ({instructorScreen}) => ({
+    lessonPage: instructorScreen.lessonPage,
+  }),
   {startFetchInstructorLessons, startFetchAllLessons}
 )(class LessonsByPage extends Component {
   
@@ -16,7 +19,8 @@ export default connect(
   }
 
   state = {
-    currentPage: 1
+    isLoading: true,
+    currentPage: 1,
   }
 
   fetchLessons = (currentPage = 1) => {
@@ -47,11 +51,13 @@ export default connect(
 
   render() {
     const {currentPage} = this.state
-    const {children, pageSize} = this.props
-    return children({
-      currentPage,
-      pageSize,
-      fetchLessons: this.fetchLessons,
-    })
+    const {lessonPage, children, pageSize} = this.props
+    return lessonPage.isLoading
+      ? <Loading />
+      : children({
+          currentPage,
+          pageSize,
+          fetchLessons: this.fetchLessons,
+        })
   }
 })

--- a/src/App/screens/Instructor/components/Loading/index.js
+++ b/src/App/screens/Instructor/components/Loading/index.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import Icon from '../Icon'
+
+export default () => (
+  <div>
+    <i class="fa fa-refresh fa-spin fa-3x fa-fw"></i>
+    <Icon
+      type='refresh'
+      size='2'
+      spin
+      className='mr2'
+    />
+    Loading...
+  </div>
+)

--- a/src/App/screens/Instructor/components/Loading/index.js
+++ b/src/App/screens/Instructor/components/Loading/index.js
@@ -2,8 +2,7 @@ import React from 'react'
 import Icon from '../Icon'
 
 export default () => (
-  <div>
-    <i class="fa fa-refresh fa-spin fa-3x fa-fw"></i>
+  <div className='mv3 gray'>
     <Icon
       type='refresh'
       size='2'

--- a/src/App/screens/Instructor/index.js
+++ b/src/App/screens/Instructor/index.js
@@ -9,6 +9,7 @@ import Overview from './screens/Overview'
 import GetPublished from './screens/GetPublished'
 import Topics from './screens/Topics'
 import Nav from './components/Nav'
+import Loading from './components/Loading'
 
 export default connect(
   ({appScreen, instructorScreen}) => ({
@@ -44,7 +45,11 @@ export default connect(
 
     if(!instructor) {
       startFetchInstructor(params.instructorId)
-      return <Main>Loading...</Main>
+      return (
+        <Main>
+          <Loading />
+        </Main>
+      )
     }
 
     if(params.instructorId !== toString(user.id)) {

--- a/src/App/screens/Instructor/state/reducers/lessonPage.js
+++ b/src/App/screens/Instructor/state/reducers/lessonPage.js
@@ -11,6 +11,7 @@ export default (
   state = {
     total: '0',
     lessons: [],
+    isLoading: false,
   },
   action
 ) => {
@@ -21,6 +22,7 @@ export default (
       const {states} = action.payload.lessonOptions
       return {
         ...state,
+        isLoading: true,
         states,
       }
 
@@ -29,6 +31,7 @@ export default (
       const {lessonPage} = action.payload
       return {
         ...state,
+        isLoading: false,
         ...lessonPage,
       }
 


### PR DESCRIPTION
# Changes

- Add loading spinner icon, component, and state

This affects every place that has a loading state: instructor root (after login), lesson loading (In Progress, Published, Requested), and future use of these components.

I'll make a PR for the styleguide for the `Icon.js` update and new `Loading` component; once styleguide library is actually built I'll just make the changes directly there and pull instead of in both places.

# Result For User

![loading](https://cloud.githubusercontent.com/assets/5497885/21658945/bc585532-d285-11e6-934b-3e7c9532d082.gif)

---

![](https://media.giphy.com/media/qIIqB1VTSumm4/giphy.gif)