### PR TITLE
Fix forbidden first login

### DIFF
--- a/src/App/state/epics/fetchUser.js
+++ b/src/App/state/epics/fetchUser.js
@@ -51,6 +51,7 @@ export default (action$, store) => (
               .then(response => response.text())
               .then(token => {
                 localStorage.setItem('token', token)
+                window.location.reload()
                 return jwt.decode(token, null, true).meta
               })
               .catch(error => {


### PR DESCRIPTION
# Changes

- Adds temporary fix for forbidden first load

Spent too much time trying to figure out why the `headers` `Bearer` localStorage token is `null` on first load, even though logging it shows the token and the components render with the user check 😕 But added this hacky fix for now so the app force reloads after login until I move to egghead.io login with JWT redirect when I will be re-writing this a bit anyways. Will probably get to that tomorrow after I finish a few other small issues.

# Result For User

Login without errors.

---

![](https://media.giphy.com/media/3NtY188QaxDdC/giphy.gif)