### PR TITLE
Add tech icon to lesson summary

### DIFF
--- a/src/App/screens/Instructor/components/LessonList/components/PaginatedLessonList/components/LessonSummary/index.js
+++ b/src/App/screens/Instructor/components/LessonList/components/PaginatedLessonList/components/LessonSummary/index.js
@@ -42,9 +42,15 @@ const LessonSummary = ({
   const nextStepForCurrentState = nextStepForCurrentStates[lesson.state]
 
   return (
-    <div className='flex-ns items-center'>
+    <div className='flex items-start'>
 
-      <div className={`mr3 ${nextStepForCurrentState ? 'w-75' : ''}`}>
+      <img
+        src={lesson.technology.logo_http_url}
+        alt={lesson.technology.label}
+        className='mw2 mr3'
+      />
+
+      <div>
         <Heading level='5'>
           {lesson.title}
         </Heading>
@@ -54,19 +60,16 @@ const LessonSummary = ({
             : '...'
           }
         </div>
-      </div>
-
-      {nextStepForCurrentState
-        ? <div className='w-25-ns mt3 mt0-ns'>
-            <Button
+        {nextStepForCurrentState
+          ? <Button
               onClick={nextStepForCurrentState.action}
-              className='w-100-ns'
+              className='mt2'
             >
               {nextStepForCurrentState.label}
             </Button>
-          </div>
-        : null
-      }
+          : null
+        }
+      </div>
 
     </div>
   )


### PR DESCRIPTION
# Changes

- Add tech icon to lesson summary to make the lessons more lively and to know what category they are in

# Result For User

<img width="340" alt="screen shot 2017-01-16 at 5 11 19 pm" src="https://cloud.githubusercontent.com/assets/5497885/22003217/11ccbae8-dc0f-11e6-9bcf-969f6520bf9f.png">

---

![](https://media.giphy.com/media/XLqaSacc9w5Zm/giphy.gif)