### PR TITLE
Add more revenue fallbacks

### DIFF
--- a/src/App/screens/Instructor/screens/Overview/components/Stats/index.js
+++ b/src/App/screens/Instructor/screens/Overview/components/Stats/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {find} from 'lodash'
+import {find, size} from 'lodash'
 import formatNumber from 'format-number'
 import {
   currentMonthRevenueTitleText,
@@ -35,15 +35,18 @@ export default ({instructor}) => {
         iconType='lesson'
         labelText={`${formatNumber({round: 2})(published_lessons)} published lessons`}
       />
-      {currentMonthRevenue
-        ? <div>
-            <div className='mv3'>
-              <RevenuePeriod
-                title={currentMonthRevenueTitleText}
-                revenue={currentMonthRevenue.revenue}
-                subscriberMinutes={currentMonthRevenue.minutes_watched}
-              />
-            </div>
+      {size(revenue) > 0
+        ? <div className='mt3'>
+            {currentMonthRevenue && currentMonthRevenue.revenue > 0
+              ? <div className='mb3'>
+                  <RevenuePeriod
+                    title={currentMonthRevenueTitleText}
+                    revenue={currentMonthRevenue.revenue}
+                    subscriberMinutes={currentMonthRevenue.minutes_watched}
+                  />
+                </div>
+              : null
+            }
             <RevenuePeriod
               title={totalRevenueTitleText}
               revenue={currentTotalRevenue.revenue}


### PR DESCRIPTION
# Changes

- Don't render revenue if it is $0
- Make revenue check more robust

# Result For User

This is what it looks like if the user has revenue, but not any for the current month:
<img width="362" alt="screen shot 2017-01-17 at 4 36 31 pm" src="https://cloud.githubusercontent.com/assets/5497885/22044727/4f423dd4-dcd3-11e6-9943-3f4262dd711d.png">

This is what it looks like if the user has no revenue:
<img width="390" alt="screen shot 2017-01-17 at 3 30 46 pm" src="https://cloud.githubusercontent.com/assets/5497885/22044738/6164d472-dcd3-11e6-90ef-7f3ebe311247.png">

---

![](https://media.giphy.com/media/LdOyjZ7io5Msw/giphy.gif)