### PR TITLE
Full admin access

### DIFF
--- a/src/App/screens/Instructor/index.js
+++ b/src/App/screens/Instructor/index.js
@@ -1,9 +1,10 @@
 import React, {Component, PropTypes} from 'react'
 import {Match} from 'react-router'
 import {connect} from 'react-redux'
-import {compact, toString} from 'lodash'
+import {compact, toString, includes} from 'lodash'
 import {forbiddenDescriptionText, forbiddenActionText} from '../../utils/text'
 import {guideUrl, chatUrl} from '../../utils/urls'
+import adminSlugs from '../../utils/adminSlugs'
 import {startRemoveUser, startShowNotification} from '../../state/actions'
 import Main from '../../components/Main'
 import {startFetchInstructor} from './state/actions'
@@ -59,7 +60,9 @@ export default connect(
       )
     }
 
-    if(params.instructorId !== toString(user.instructor_id)) {
+    const hasAccess = includes(adminSlugs, params.instructorId)
+      || params.instructorId === toString(user.instructor_id)
+    if(!hasAccess) {
       startShowNotification({
         type: 'error',
         message: forbiddenDescriptionText,

--- a/src/App/screens/Instructor/index.js
+++ b/src/App/screens/Instructor/index.js
@@ -60,7 +60,7 @@ export default connect(
       )
     }
 
-    const hasAccess = includes(adminSlugs, params.instructorId)
+    const hasAccess = includes(adminSlugs, user.instructor_id)
       || params.instructorId === toString(user.instructor_id)
     if(!hasAccess) {
       startShowNotification({

--- a/src/App/utils/adminSlugs.js
+++ b/src/App/utils/adminSlugs.js
@@ -1,0 +1,5 @@
+export default [
+  'joel-hooks',
+  'john-lindquist',
+  'trevor-miller',
+]


### PR DESCRIPTION
# Changes

- Give @joelhooks, @johnlindquist, and myself full access to view any route; mainly for testing and support but also so we can creepily spy on people ;) Not that useful as is as you would need to know instructor slugs, but I'm going to add a simple admin directory that links to everyone  in another PR.

# Result For User

![full-admin-access](https://cloud.githubusercontent.com/assets/5497885/22088999/6f79d45e-dda5-11e6-9a78-6af08020c9e1.gif)

---

![](https://media.giphy.com/media/aZFOWrwntNJuw/giphy.gif)