### PR TITLE
Fix instructor caching bug

### DIFF
--- a/src/App/screens/Instructor/index.js
+++ b/src/App/screens/Instructor/index.js
@@ -57,15 +57,6 @@ export default connect(
       lessonPage,
     } = this.props
 
-    if(!instructor) {
-      startFetchInstructor(params.instructorId)
-      return (
-        <Main>
-          <Loading />
-        </Main>
-      )
-    }
-
     const isAdmin = includes(adminSlugs, user.instructor_id)
     const isOwnPages = params.instructorId === toString(user.instructor_id)
     const hasAccess = isAdmin || isOwnPages 
@@ -80,6 +71,15 @@ export default connect(
         },
       })
       return null
+    }
+
+    if(!instructor || params.instructorId !== instructor.slug) {
+      startFetchInstructor(params.instructorId)
+      return (
+        <Main>
+          <Loading />
+        </Main>
+      )
     }
 
     return (


### PR DESCRIPTION
# Changes

- Fix caching bug, so instructor routes refresh data when switching to a new instructor route
- Moving loading logic below permissions check on instructor so instructor only loads if needed

# Result For User

![caching-instructor-pulse-links](https://cloud.githubusercontent.com/assets/5497885/22161578/34020432-df08-11e6-8659-3b7e7ae7b21d.gif)

---

![](https://media.giphy.com/media/3oEjI6SIIHBdRxXI40/giphy.gif)