### PR TITLE
Don't send instructor_id when submitting lessons by admins

### DIFF
--- a/src/App/components/Submit/index.js
+++ b/src/App/components/Submit/index.js
@@ -59,7 +59,7 @@ export default connect(
       technology_id: technologyId,
       summary: summary,
       state: type,
-      instructor_id: instructor ? instructor.id : null,
+      ...(instructor ? {instructor_id: instructor.id} : {}),
     })
     this.setState(clearedState)
     startShowNotification({


### PR DESCRIPTION
# Changes

Fix null instructor_id

---

![](https://media.giphy.com/media/bzcjCvn2dqPWE/source.gif)