### PR TITLE
Admin requested submissions bug

### DIFF
--- a/src/App/components/Submit/index.js
+++ b/src/App/components/Submit/index.js
@@ -59,7 +59,7 @@ export default connect(
       technology_id: technologyId,
       summary: summary,
       state: type,
-      instructor_id: instructor ? instructor.id : null,
+      ...(instructor ? {instructor_id: instructor.id} : {}),
     })
     this.setState(clearedState)
     startShowNotification({

--- a/src/App/screens/Instructor/state/reducers/lessonPage.js
+++ b/src/App/screens/Instructor/state/reducers/lessonPage.js
@@ -21,7 +21,6 @@ export default (
     case STARTED_FETCH_ALL_LESSONS:
       const {states} = action.payload.lessonOptions
       return {
-        ...state,
         isLoading: true,
         states,
       }
@@ -30,7 +29,6 @@ export default (
     case ENDED_FETCH_ALL_LESSONS:
       const {lessonPage} = action.payload
       return {
-        ...state,
         isLoading: false,
         ...lessonPage,
       }

--- a/src/App/state/actions/index.js
+++ b/src/App/state/actions/index.js
@@ -36,13 +36,11 @@ export const endShowNotification = () => ({
 })
 
 export const startUpdateLessonState = ({
-  instructorId,
   lesson,
   newState,
 }) => ({
   type: appActionTypes.STARTED_UPDATE_LESSON_STATE,
   payload: {
-    instructorId,
     lesson,
     newState,
   },

--- a/src/App/state/epics/submitLesson.js
+++ b/src/App/state/epics/submitLesson.js
@@ -44,7 +44,6 @@ export default (action$, store) => (
       ({payload}, lesson) => {
         if(payload.lesson.state && !process.env.REACT_APP_FAKE_API) {
           store.dispatch(startUpdateLessonState({
-            instructorId: lesson.instructor_id,
             lesson,
             newState: payload.lesson.state,
           }))

--- a/src/App/state/epics/updateLessonState.js
+++ b/src/App/state/epics/updateLessonState.js
@@ -35,7 +35,6 @@ export default (action$, store) => (
             body: process.env.REACT_APP_FAKE_API
               ? JSON.stringify({
                 ...payload.lesson,
-                instructor_id: payload.instructorId,
                 state: payload.newState,
               })
               : null,


### PR DESCRIPTION
# Changes

- Remove local caching that should be fresh server data (was causing lessons to not be updated with latest data from server)
- Remove state pieces no longer used

---

# Result for user

![admin-new-requested-lessons](https://cloud.githubusercontent.com/assets/5497885/22222967/538bae1e-e176-11e6-8293-0e966e63a906.gif)

![](https://media.giphy.com/media/6cFcUiCG5eONW/giphy.gif)