### PR TITLE
Add google analytics tracking code

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "font-awesome": "^4.6.3",
     "format-number": "^2.0.1",
-    "honeybadger-js": "^0.4.3",
     "jwt-simple": "^0.5.1",
     "lodash": "^4.16.2",
     "parse-link-header": "^0.4.1",

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,14 @@
     <link rel='manifest' href='/manifest.json'>
     <link rel='mask-icon' href='/safari-pinned-tab.svg' color='#555555'>
     <meta name='theme-color' content='#ffffff'>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-36512724-2', 'auto');
+      ga('send', 'pageview');
+    </script>
     <script src='https://js.honeybadger.io/v0.4/honeybadger.min.js' type='text/javascript' data-api_key='a476256e' data-environment='production'></script>
   </head>
   <body>

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -1,17 +1,9 @@
 import React from 'react'
 import {Provider} from 'react-redux'
-import Honeybadger from 'honeybadger-js'
 import configureStore from './state/'
-import {honeybadgerKey} from './utils/keys'
 import Router from './components/Router'
 
 const store = configureStore()
-
-if (process.env.NODE_ENV === 'production') {
-  Honeybadger.configure({
-    api_key: honeybadgerKey,
-  })
-}
 
 export default (props) => (
   <Provider store={store}>

--- a/src/App/utils/keys.js
+++ b/src/App/utils/keys.js
@@ -1,1 +1,0 @@
-export const honeybadgerKey = 'a476256e'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,10 +2586,6 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-honeybadger-js@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-0.4.3.tgz#624796f10c92074ea4e8cd91751e062f4a942191"
-
 hosted-git-info@^2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"


### PR DESCRIPTION
# Changes

- Add tracking code inline with honeybadger. Would like to move this into src module with specific events in the future and additionally track user data + redux events etc, but this works for now.

---

![](https://media.giphy.com/media/TK4yMeRswlKWA/giphy.gif)