### PR TITLE
Fix active navigation items

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-addons-create-fragment": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-paginate": "^2.2.3",
-    "react-router-dom": "4.0.0-beta.3",
+    "react-router-dom": "4.0.0-beta.5",
     "react-tabs": "^0.8.2",
     "react-truncate": "^1.1.4",
     "sort-by": "^1.2.0",

--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -87,6 +87,7 @@ export default class Navigation extends Component {
               else {
                 return startsWith(item.action, '/')
                   ? <NavLink
+                      exact
                       key={index}
                       className={sharedLinkClassnames}
                       activeClassName={activeLinkClassnames}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4292,16 +4292,16 @@ react-paginate@^2.2.3:
   dependencies:
     classnames "^2.2.5"
 
-react-router-dom@4.0.0-beta.3:
-  version "4.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.0.0-beta.3.tgz#3b7e98d8b9e03d61acab0fcccaabc1cf1723ce5f"
+react-router-dom@4.0.0-beta.5:
+  version "4.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.0.0-beta.5.tgz#cb104b789d3a7af159c06ce76e7253978447f9aa"
   dependencies:
     history "^4.5.1"
-    react-router "^4.0.0-beta.3"
+    react-router "^4.0.0-beta.5"
 
-react-router@^4.0.0-beta.3:
-  version "4.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.0.0-beta.4.tgz#6ab21755525ae3dfe7cca5e0176b05385a7b854d"
+react-router@^4.0.0-beta.5:
+  version "4.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.0.0-beta.5.tgz#f1852e953d2aad942a7502786e32b9f56b4ae020"
   dependencies:
     history "^4.5.1"
     invariant "^2.2.2"
@@ -5332,13 +5332,9 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@1.0.0:
+whatwg-fetch@1.0.0, whatwg-fetch@>=0.10.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz#01c2ac4df40e236aaa18480e3be74bd5c8eb798e"
-
-whatwg-fetch@>=0.10.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz#fe294d1d89e36c5be8b3195057f2e4bc74fc980e"
 
 whatwg-url@^4.1.0:
   version "4.3.0"


### PR DESCRIPTION
# Changes

- Fix active navigation items by upgrading to react router beta.5 with new `exact` prop on `NavLink`

# Result For User

Only makes exact route NavLink active, instead of always matching on "Overview" root as it did with initial beta upgrade.
<img width="374" alt="screen shot 2017-02-08 at 10 45 33 am" src="https://cloud.githubusercontent.com/assets/5497885/22749892/115786f8-edec-11e6-8a44-3079dcc04a85.png">

---

![](https://media.giphy.com/media/3o7TKw3JFXXfOYVN9m/giphy.gif)