### PR TITLE
Remove cancelled lessons from in progress

### DIFF
--- a/src/utils/lessonStates/index.js
+++ b/src/utils/lessonStates/index.js
@@ -1,4 +1,4 @@
-import {slice, indexOf} from 'lodash'
+import {slice, indexOf, without} from 'lodash'
 import {
   proposedStateDescriptionText,
   cancelledStateDescriptionText,
@@ -45,11 +45,11 @@ const lessonStates = [
 
 export default lessonStates
 
-export const inProgressLessonStates = slice(
+export const inProgressLessonStates = without(slice(
   lessonStates,
   indexOf(lessonStates, 'proposed'),
   indexOf(lessonStates, 'published')
-)
+), 'cancelled')
 
 export const publishedLessonStates = slice(
   lessonStates,

--- a/src/utils/lessonStates/index.test.js
+++ b/src/utils/lessonStates/index.test.js
@@ -3,7 +3,6 @@ import {inProgressLessonStates, publishedLessonStates} from '.'
 test('in progress', () => (
   expect(inProgressLessonStates).toEqual([
     'proposed',
-    'cancelled',
     'accepted',
     'requested',
     'claimed',


### PR DESCRIPTION
# Changes

- Don't show "cancelled" lessons in in progress

This was feedback from @mariusschulz and I agree showing cancelled lessons is pretty useless and confusing.

# Result For User

![hide-cancel](https://cloud.githubusercontent.com/assets/5497885/22758055/3ee1bbca-ee0a-11e6-8c1f-a7c24be5bdbd.gif)

---

![](https://media.giphy.com/media/6h3m8duUqsjNm/giphy.gif)