### PR TITLE
Add initial tachyons-egghead styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-tabs": "^0.8.2",
     "react-truncate": "^1.1.4",
     "sort-by": "^1.2.0",
-    "tachyons-egghead": "^1.2.0"
+    "tachyons-egghead": "^1.2.1"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-tabs": "^0.8.2",
     "react-truncate": "^1.1.4",
     "sort-by": "^1.2.0",
-    "tachyons": "^4.5.3"
+    "tachyons-egghead": "^1.2.0"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
       ga('send', 'pageview');
     </script>
   </head>
-  <body>
+  <body class='bg-navy white min-vh-100'>
     <div id='root'></div>
   </body>
 </html>

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -4,7 +4,7 @@ export default ({children, onClick, subtle}) => (
   <button
     className={`
       button-reset bn dib b0 ttu dim br2 ph3 pv2 tc
-      white ${subtle ? 'bg-black-50' : 'bg-orange'}
+      ${subtle ? 'bg-white navy' : 'bg-blue white'}
     `}
     onClick={onClick}
   >

--- a/src/components/LessonList/components/PaginatedLessonList/components/LessonSummary/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/components/LessonSummary/index.js
@@ -24,8 +24,8 @@ export default ({instructor, lesson}) => {
         <div className={`
           mb2 ttu tc pa1 br2 ba f6 dib
           ${statusByLessonState[lesson.state].requiresUserAction
-            ? 'orange b--orange'
-            : 'b--black-50'
+            ? 'blue b--blue'
+            : 'yellow b--yellow'
           }
         `}>
           {lesson.state}

--- a/src/components/LessonList/components/PaginatedLessonList/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/index.js
@@ -23,49 +23,52 @@ const PaginatedLessonList = ({
   }
 
   return (
-    total > 0
-      ? <div>
+    <div className='bg-light-navy'>
+      {total > 0
+        ? <div>
 
-          <div className='bg-light-gray br2'>
-            {map(sortLessonsByState(lessons), (lesson, index) => (
-              <div
-                key={index}
-                className='bb b--black-20 pa3'
-              >
-                <LessonSummary lesson={lesson} />
-              </div>
-            ))}
+            <div className='br2'>
+              {map(sortLessonsByState(lessons), (lesson, index) => (
+                <div
+                  key={index}
+                  className='bb b--navy pa3'
+                >
+                  <LessonSummary lesson={lesson} />
+                </div>
+              ))}
+            </div>
+
+            {hasMoreThanOnePage
+              ? <ReactPaginate
+                  pageNum={pageNum}
+                  pageRangeDisplayed={3}
+                  marginPagesDisplayed={1}
+                  initialSelected={currentPage - 1}
+                  previousLabel={previousLabelText}
+                  nextLabel={nextLabelText}
+                  clickCallback={(page) => {
+                    const {selected} = page
+                    if (currentPage !== selected + 1) {
+                      requestNextPage(selected + 1)
+                    }
+                  }}
+                  containerClassName='mb0 pa0 list mt4 flex items-center'
+                  previousClassName={linkClassNames.mobileHide}
+                  nextClassName={linkClassNames.mobileHide}
+                  disabledClassName='o-20'
+                  previousLinkClassName={linkClassNames.link}
+                  nextLinkClassName={linkClassNames.link}
+                  pageLinkClassName={linkClassNames.link}
+                  activeClassName='o-50'
+                  breakClassName='mr2'
+                />
+              : null
+            }
+
           </div>
-
-          {hasMoreThanOnePage
-            ? <ReactPaginate
-                pageNum={pageNum}
-                pageRangeDisplayed={3}
-                marginPagesDisplayed={1}
-                initialSelected={currentPage - 1}
-                previousLabel={previousLabelText}
-                nextLabel={nextLabelText}
-                clickCallback={(page) => {
-                  const {selected} = page
-                  if (currentPage !== selected + 1) {
-                    requestNextPage(selected + 1)
-                  }
-                }}
-                containerClassName='mb0 pa0 list mt4 flex items-center'
-                previousClassName={linkClassNames.mobileHide}
-                nextClassName={linkClassNames.mobileHide}
-                disabledClassName='o-20'
-                previousLinkClassName={linkClassNames.link}
-                nextLinkClassName={linkClassNames.link}
-                pageLinkClassName={linkClassNames.link}
-                activeClassName='o-50'
-                breakClassName='mr2'
-              />
-            : null
-          }
-
-        </div>
-      : fallback
+        : fallback
+      }
+    </div>
   )
 }
 

--- a/src/components/Loading/index.js
+++ b/src/components/Loading/index.js
@@ -3,7 +3,7 @@ import {loadingTitleText} from 'utils/text'
 import Icon from 'components/Icon'
 
 export default () => (
-  <div className='ma3 gray'>
+  <div className='ma4 white'>
     <Icon
       type='refresh'
       size='2'

--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -7,13 +7,13 @@ import Logo from 'components/Logo'
 const sharedLinkClassnames = `
   pointer
   f6
-  pv3 pv4-ns ph4 ph3-ns
+  pv3 ph4
   ttu
   no-underline
-  white-60 
+  gray
 `
 
-const activeLinkClassnames = 'bl bl-0-ns bb-ns bw2 bw1-ns b--orange white'
+const activeLinkClassnames = 'bl bl-0-ns bb-ns bw2 bw1-ns b--yellow white'
 
 export default class Navigation extends Component {
   
@@ -49,7 +49,7 @@ export default class Navigation extends Component {
     const {isOpen} = this.state
 
     return (
-      <header className='bg-black-70'>
+      <header className='bg-light-navy'>
 
         <div className='
           mw8 center relative
@@ -61,13 +61,13 @@ export default class Navigation extends Component {
           </div>
 
           <nav className={`
-            pv3 pv0-ns
+            pv2 pv0-ns
             ml4-ns
             ${isOpen
               ? 'flex'
               : 'dn'
             }
-            flex-ns flex-column flex-row-ns
+            flex-ns flex-column flex-row-ns flex-wrap
           `}>
             {map(items, (item, index) => {
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const App = () => {
 
         return (
           <BrowserRouter>
-            <div className='bg-navy white min-vh-100'>
+            <div>
 
               <Navigation
                 items={[

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import 'tachyons'
+import 'tachyons-egghead'
 import 'font-awesome/css/font-awesome.min.css'
 import React from 'react'
 import ReactDOM from 'react-dom'

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const App = () => {
 
         return (
           <BrowserRouter>
-            <div>
+            <div className='bg-navy white min-vh-100'>
 
               <Navigation
                 items={[

--- a/src/screens/Instructors/components/InstructorsList/index.js
+++ b/src/screens/Instructors/components/InstructorsList/index.js
@@ -9,22 +9,24 @@ export default ({title, instructors}) => (
     <Heading level='2'>
       {title}
     </Heading>
-    {size(instructors) > 0
-      ? <div>
-          <div className='bg-light-gray br2'>
-            {map(instructors, (instructor) => (
-              <div
-                key={instructor.id}
-                className='bb b--black-20 pa3'
-              >
-                <InstructorSummary instructor={instructor} />
-              </div>
-            ))}
+    <div className='bg-light-navy'>
+      {size(instructors) > 0
+        ? <div>
+            <div className='br2'>
+              {map(instructors, (instructor) => (
+                <div
+                  key={instructor.id}
+                  className='bb b--navy pa3'
+                >
+                  <InstructorSummary instructor={instructor} />
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-      : <div>
-          {noInstructorsDescriptionText}
-        </div>
-    }
+        : <div>
+            {noInstructorsDescriptionText}
+          </div>
+      }
+    </div>
   </div>
 )

--- a/src/screens/Lessons/screens/Lesson/components/LessonData/index.js
+++ b/src/screens/Lessons/screens/Lesson/components/LessonData/index.js
@@ -65,7 +65,7 @@ export default ({lesson}) => {
       {map(items, (item, index) => (
         <div 
           key={index}
-          className={`${index < (size(items) - 1) ? 'bb' : ''} pb3 mb3 b--black-30`}
+          className={`${index < (size(items) - 1) ? 'bb' : ''} pb3 mb3 b--gray`}
         >
           <Heading level='4'>
             {item.title}

--- a/src/screens/Lessons/screens/Lesson/components/LessonNextSteps/index.js
+++ b/src/screens/Lessons/screens/Lesson/components/LessonNextSteps/index.js
@@ -13,8 +13,8 @@ export default ({lesson}) => (
         {statusTitleText}
       </Heading>
       <div className={`
-        mb2 ttu tc pa2 br2 ba
-        ${statusByLessonState[lesson.state].requiresUserAction ? 'orange b--orange' : 'b--black-50'}
+        mb3 ttu tc pv2 ph3 br2 ba dib
+        ${statusByLessonState[lesson.state].requiresUserAction ? 'blue b--blue' : 'yellow b--yellow'}
       `}>
         {lesson.state}
       </div>
@@ -22,7 +22,7 @@ export default ({lesson}) => (
         {statusByLessonState[lesson.state].description}
       </div>
 
-      <div className='flex flex-wrap'>
+      <div className='flex flex-wrap mt3'>
         {map(keys(actionByLessonState), (state, index) => {
           const stateUrl = lesson[`${state}_url`]
           return stateUrl

--- a/src/screens/Lessons/screens/New/components/Propose/index.js
+++ b/src/screens/Lessons/screens/New/components/Propose/index.js
@@ -13,7 +13,7 @@ import Heading from 'components/Heading'
 import Button from 'components/Button'
 import Error from 'components/Error'
 
-const inputClassNames = 'input-reset pa2 br2 ba b--black-20 w-100'
+const inputClassNames = 'input-reset pa2 br2 bg-dark-navy white ba b--light-navy w-100'
 
 const clearedState = {
   title: '',
@@ -71,8 +71,8 @@ export default class Propose extends Component {
           {newLessonSubmissionDescriptionText}
         </div>
 
-        <div className='mb2'>
-          <div className='b gray'>
+        <div className='mb3'>
+          <div className='b'>
             {lessonTitleLabelText}
           </div>
           <input
@@ -85,8 +85,8 @@ export default class Propose extends Component {
 
         <Request url='/api/v1/technologies'>
           {({data}) => (
-            <div className='mb2'>
-              <div className='b gray'>
+            <div className='mb3'>
+              <div className='b'>
                 {lessonTechnologyLabelText}
               </div>
               <select
@@ -108,8 +108,8 @@ export default class Propose extends Component {
           )}
         </Request>
 
-        <div className='mb2'>
-          <div className='b gray'>
+        <div className='mb3'>
+          <div className='b'>
             {lessonSummaryLabelText}
           </div>
           <textarea
@@ -122,7 +122,7 @@ export default class Propose extends Component {
         </div>
 
         {hasMissingInput
-          ? <div className='mb2'>
+          ? <div className='mb3'>
               <Error>
                 {missingInputDescriptionText}
               </Error>

--- a/src/screens/Lessons/screens/New/components/Requested/index.js
+++ b/src/screens/Lessons/screens/New/components/Requested/index.js
@@ -21,7 +21,7 @@ export default () => (
     <LessonList
       states={['requested']} 
       fallback={
-        <div className='mv3 i gray'>
+        <div className='mv3 pa3 br2 i gray'>
           {requestedEmptyDescriptionText}
         </div>
       }

--- a/src/screens/Overview/components/InstructorLessons/components/Prompt/index.js
+++ b/src/screens/Overview/components/InstructorLessons/components/Prompt/index.js
@@ -7,8 +7,8 @@ export default ({
   actionText,
   action,
 }) => (
-  <div>
-    <div className='i orange'>
+  <div className='pa3'>
+    <div className='i'>
       {description}
     </div>
     {action

--- a/src/screens/Overview/components/InstructorLessons/components/Tabs/index.js
+++ b/src/screens/Overview/components/InstructorLessons/components/Tabs/index.js
@@ -22,7 +22,7 @@ export default class extends Component {
     return (
       <Tabs onSelect={this.handleSelect}>
 
-        <TabList className='list pa0 ma0 bg-moon-gray flex-ns br2 br--top'>
+        <TabList className='list pa0 ma0 bg-light-navy flex-ns br2 br--top'>
           {map(groups, (group, index) => (
             <Tab
               key={index}
@@ -33,8 +33,8 @@ export default class extends Component {
                 pointer
                 bl bl-0-ns bb-ns bw2 bw1-ns
                 ${this.state.selected === index
-                  ? 'b--orange black'
-                  : 'b--transparent black-40'
+                  ? 'b--yellow'
+                  : 'b--transparent gray'
                 }
               `}
             >

--- a/src/screens/Overview/components/InstructorLessons/index.js
+++ b/src/screens/Overview/components/InstructorLessons/index.js
@@ -26,13 +26,11 @@ export default ({instructor}) => (
           <LessonList
             states={inProgressLessonStates}
             fallback={
-              <div className='mt3'>
-                <Prompt
-                  description={noInProgressLessonsDescriptionText}
-                  actionText={newLessonsActionText}
-                  action={'/lessons/new'}
-                />
-              </div>
+              <Prompt
+                description={noInProgressLessonsDescriptionText}
+                actionText={newLessonsActionText}
+                action={'/lessons/new'}
+              />
             }
             instructor={instructor}
           />
@@ -44,9 +42,7 @@ export default ({instructor}) => (
           <LessonList
             states={publishedLessonStates}
             fallback={
-              <div className='mt3'>
-                <Prompt description={noPublishedLessonsDescriptionText} />
-              </div>
+              <Prompt description={noPublishedLessonsDescriptionText} />
             }
             instructor={instructor}
           />

--- a/src/screens/Overview/components/NextMilestone/components/GetPublished/components/Checklist/index.js
+++ b/src/screens/Overview/components/NextMilestone/components/GetPublished/components/Checklist/index.js
@@ -22,7 +22,7 @@ const Checklist = ({items, instructorId}) => (
             : <Icon
                 type='step-incomplete'
                 size='2'
-                className='orange'
+                className='yellow'
               />
           }
         </div>
@@ -31,7 +31,7 @@ const Checklist = ({items, instructorId}) => (
           <div>
             <span className={item.isComplete
               ? 'strike gray'
-              : 'orange'
+              : 'yellow'
             }>
               {item.description}
             </span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,6 +3630,10 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+normalize.css@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-5.0.0.tgz#7cec875ce8178a5333c4de80b68ea9c18b9d7c37"
+
 npmlog@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
@@ -4966,9 +4970,296 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-tachyons@^4.5.3:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/tachyons/-/tachyons-4.6.2.tgz#cf006fd516763e735b33565fc21b8b3616a012c8"
+tachyons-aspect-ratios@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tachyons-aspect-ratios/-/tachyons-aspect-ratios-1.0.1.tgz#4b30e0dd105b2331f722baf8bf013c8f43c82c40"
+
+tachyons-background-position@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tachyons-background-position/-/tachyons-background-position-1.0.3.tgz#dca3bb6181f3aa4feab2b81dcc64b0551f253706"
+
+tachyons-background-size@^5.0.4:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/tachyons-background-size/-/tachyons-background-size-5.0.5.tgz#445fbe008125308ebe750262649e3f3f7c9de56f"
+
+tachyons-base@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/tachyons-base/-/tachyons-base-1.2.6.tgz#1ed5ce2497ac414df0eb2a77a6324cad50ba90af"
+
+"tachyons-border-colors@github:eggheadio/tachyons-border-colors":
+  version "4.2.3"
+  resolved "https://codeload.github.com/eggheadio/tachyons-border-colors/tar.gz/ac593925017b51f497d6c79734bf338dbada016c"
+
+tachyons-border-radius@^5.1.2:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/tachyons-border-radius/-/tachyons-border-radius-5.1.3.tgz#b4677a6c8951ab8ba7a3d6e797a6c896db74f1f7"
+
+tachyons-border-style@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-border-style/-/tachyons-border-style-4.0.4.tgz#b629f8dcab31302ce3bb5f2019de5825412aea97"
+
+tachyons-border-widths@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-border-widths/-/tachyons-border-widths-3.0.4.tgz#f4e2f33d102329b0c1427ec5af2ce6fe730ee79a"
+
+tachyons-borders@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-borders/-/tachyons-borders-3.0.4.tgz#4d52c19ad3bcb7817a5c1078a2eb9dfb0b3dc40f"
+
+tachyons-box-shadow@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-box-shadow/-/tachyons-box-shadow-2.0.4.tgz#a3bf4650efd67cffcfedce2489d8ba522644000c"
+
+tachyons-box-sizing@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/tachyons-box-sizing/-/tachyons-box-sizing-3.2.1.tgz#2f6f5005717746ce9e33fbedddbd5f637c8faeab"
+
+tachyons-clears@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-clears/-/tachyons-clears-3.0.4.tgz#8464bfa0394fbad2e6ab97fadf8bc7ecbe2eb695"
+
+tachyons-code@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tachyons-code/-/tachyons-code-1.0.0.tgz#5c3defc4b9250c64227dcf95b961fc5c1d8fcb28"
+
+"tachyons-colors@github:eggheadio/tachyons-colors":
+  version "5.3.2"
+  resolved "https://codeload.github.com/eggheadio/tachyons-colors/tar.gz/14b9db57b1d21be9c22707e859b9150c10c40c05"
+
+tachyons-coordinates@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-coordinates/-/tachyons-coordinates-4.0.4.tgz#d20f9d5941b6782ff28e1778be71e895457a6cdd"
+
+tachyons-custom@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/tachyons-custom/-/tachyons-custom-4.5.4.tgz#0299564dc3217e2171d2723e39b69a22f739beae"
+
+tachyons-debug-grid@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/tachyons-debug-grid/-/tachyons-debug-grid-1.2.3.tgz#42246147b613b16ce80fb90be7409206608a15cb"
+
+tachyons-debug@^1.1.9:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/tachyons-debug/-/tachyons-debug-1.1.10.tgz#3eaaa05e2d0714d7bcfa8972991f67ddc8cc980b"
+
+tachyons-display@^5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-display/-/tachyons-display-5.0.4.tgz#9ec6918b0695753b7c296c0a1275c8b214b25b9a"
+
+tachyons-egghead@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tachyons-egghead/-/tachyons-egghead-1.2.0.tgz#19b14d42ad9e790565898f23a5e41965c75a5fda"
+  dependencies:
+    normalize.css "^5.0.0"
+    tachyons-aspect-ratios "^1.0.1"
+    tachyons-background-position "^1.0.3"
+    tachyons-background-size "^5.0.4"
+    tachyons-base "^1.2.6"
+    tachyons-border-colors "github:eggheadio/tachyons-border-colors"
+    tachyons-border-radius "^5.1.2"
+    tachyons-border-style "^4.0.3"
+    tachyons-border-widths "^3.0.3"
+    tachyons-borders "^3.0.3"
+    tachyons-box-shadow "^2.0.3"
+    tachyons-box-sizing "^3.2.0"
+    tachyons-clears "^3.0.3"
+    tachyons-code "^1.0.0"
+    tachyons-colors "github:eggheadio/tachyons-colors"
+    tachyons-coordinates "^4.0.3"
+    tachyons-custom "^4.5.4"
+    tachyons-debug "^1.1.9"
+    tachyons-debug-grid "^1.2.2"
+    tachyons-display "^5.0.3"
+    tachyons-flexbox "github:eggheadio/tachyons-flexbox"
+    tachyons-floats "^3.0.3"
+    tachyons-font-family "^4.3.2"
+    tachyons-font-style "^4.0.3"
+    tachyons-font-weight "^5.0.3"
+    tachyons-forms "^3.1.2"
+    tachyons-heights "^6.1.2"
+    tachyons-hovers "^2.5.0"
+    tachyons-images "^1.0.10"
+    tachyons-letter-spacing "^3.0.3"
+    tachyons-line-height "^3.0.5"
+    tachyons-links "^3.0.8"
+    tachyons-lists "^2.0.11"
+    tachyons-max-widths "^4.0.3"
+    tachyons-negative-margin "^1.0.0"
+    tachyons-opacity "^1.1.7"
+    tachyons-outlines "^1.0.2"
+    tachyons-overflow "^4.0.3"
+    tachyons-position "^6.0.3"
+    tachyons-queries "^0.3.3"
+    tachyons-rotations "^1.0.2"
+    tachyons-skins "github:eggheadio/tachyons-skins"
+    tachyons-skins-pseudo "github:eggheadio/tachyons-skins-pseudo"
+    tachyons-spacing "^6.0.3"
+    tachyons-styles "^0.3.4"
+    tachyons-tables "^1.0.6"
+    tachyons-text-align "^3.0.3"
+    tachyons-text-decoration "^4.0.3"
+    tachyons-text-transform "^4.0.3"
+    tachyons-type-scale "^6.0.3"
+    tachyons-typography "^3.0.3"
+    tachyons-utilities "^2.0.0"
+    tachyons-vertical-align "^4.0.3"
+    tachyons-visibility "^2.0.3"
+    tachyons-white-space "^4.0.4"
+    tachyons-widths "^5.1.0"
+    tachyons-word-break "^3.0.3"
+    tachyons-z-index "^1.0.7"
+
+"tachyons-flexbox@github:eggheadio/tachyons-flexbox":
+  version "2.0.3"
+  resolved "https://codeload.github.com/eggheadio/tachyons-flexbox/tar.gz/6e8ddffddd2e23870e8821880b87757e9609aeb4"
+
+tachyons-floats@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-floats/-/tachyons-floats-3.0.4.tgz#cca5deeeacc94880b801ac79a6bca64708e55e6c"
+
+tachyons-font-family@^4.3.2:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/tachyons-font-family/-/tachyons-font-family-4.3.3.tgz#e3630a5382922a78d5515d1cd970c7a3f954d17d"
+
+tachyons-font-style@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-font-style/-/tachyons-font-style-4.0.4.tgz#85db7376de302515a97a71264f828907b5ab1389"
+
+tachyons-font-weight@^5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-font-weight/-/tachyons-font-weight-5.0.4.tgz#c95b4feb7f4c18558859bbc9af13197981d18d60"
+
+tachyons-forms@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/tachyons-forms/-/tachyons-forms-3.1.3.tgz#5a95b7969ab467f3b3b2435f38456880d9649f95"
+
+tachyons-heights@^6.1.2:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/tachyons-heights/-/tachyons-heights-6.1.3.tgz#7eae3d3c86dd6960101006fbfd9289446c6e41fe"
+
+tachyons-hovers@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/tachyons-hovers/-/tachyons-hovers-2.5.1.tgz#dabea2935231c102c78fdeb7e384112b51e54ae4"
+
+tachyons-images@^1.0.10:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/tachyons-images/-/tachyons-images-1.0.11.tgz#5aeab7eb2a9ab8e6ca792e38c322edc8e34a5822"
+
+tachyons-letter-spacing@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-letter-spacing/-/tachyons-letter-spacing-3.0.4.tgz#6cd3af529b24e55e577626e6b1e84a4b844ebcfd"
+
+tachyons-line-height@^3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/tachyons-line-height/-/tachyons-line-height-3.0.6.tgz#e5b4e116f9aadec530438a62d3fd043c7785b300"
+
+tachyons-links@^3.0.8:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/tachyons-links/-/tachyons-links-3.0.9.tgz#062ce35013b322b1372dc89af61fc45cc877e245"
+
+tachyons-lists@^2.0.11:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/tachyons-lists/-/tachyons-lists-2.0.12.tgz#a38f54517f5d7b3a5518b4671e2924df9d18b037"
+
+tachyons-max-widths@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-max-widths/-/tachyons-max-widths-4.0.4.tgz#a69383f9d8543f7d11b33ac792392930e6693260"
+
+tachyons-negative-margin@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tachyons-negative-margin/-/tachyons-negative-margin-1.0.0.tgz#81237cf806faea9697da0886bbff5eb227a1e212"
+
+tachyons-opacity@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/tachyons-opacity/-/tachyons-opacity-1.1.8.tgz#d4b270c12b71921b6c5ba6ad329ccea0e7f81995"
+
+tachyons-outlines@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tachyons-outlines/-/tachyons-outlines-1.0.2.tgz#fe9125a9f66d944c277d767cd1abe5bb923adb29"
+
+tachyons-overflow@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-overflow/-/tachyons-overflow-4.0.4.tgz#7e1f956949ffe698fda38221d41d5201c6b2c5b2"
+
+tachyons-position@^6.0.3:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-position/-/tachyons-position-6.0.4.tgz#3969217ace21c114ab923c8882240cf7f947cabe"
+
+tachyons-queries@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/tachyons-queries/-/tachyons-queries-0.3.3.tgz#de549f2ffb7f479ae2bfff21c78a6b30275ea3b6"
+
+tachyons-rotations@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tachyons-rotations/-/tachyons-rotations-1.0.2.tgz#19bb7cc29aceaea56dc02b650241dafa32f0de62"
+
+"tachyons-skins-pseudo@github:eggheadio/tachyons-skins-pseudo":
+  version "1.0.3"
+  resolved "https://codeload.github.com/eggheadio/tachyons-skins-pseudo/tar.gz/4696c873ca59eeeabf554dce4a71b9e406a01296"
+
+"tachyons-skins@github:eggheadio/tachyons-skins":
+  version "4.0.2"
+  resolved "https://codeload.github.com/eggheadio/tachyons-skins/tar.gz/59502baf4292ecefed027ec7f92afab51cd8655a"
+
+tachyons-spacing@^6.0.3:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-spacing/-/tachyons-spacing-6.0.4.tgz#54cbd6d902b2a36ab864110754ec9924e09935aa"
+
+tachyons-styles@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/tachyons-styles/-/tachyons-styles-0.3.4.tgz#bd1c3fdf62b27df07e4be17a7d3adda2c89ef71d"
+
+tachyons-tables@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/tachyons-tables/-/tachyons-tables-1.0.7.tgz#2f914bbdb07c7b232cb15392d716f4c965d0770a"
+
+tachyons-text-align@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-text-align/-/tachyons-text-align-3.0.4.tgz#444f09db34b11fd6e6787b665f12348f92f99ee9"
+
+tachyons-text-decoration@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-text-decoration/-/tachyons-text-decoration-4.0.4.tgz#47d724c83e9f0f6d68e301721fd4db6c321349bc"
+
+tachyons-text-transform@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-text-transform/-/tachyons-text-transform-4.0.4.tgz#7b009e4b1ff3b571053d0239f00b9c3bce67114d"
+
+tachyons-type-scale@^6.0.3:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-type-scale/-/tachyons-type-scale-6.0.4.tgz#37f8bcd4fef64698f49d49acf791f4718604f0ba"
+
+tachyons-typography@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-typography/-/tachyons-typography-3.0.4.tgz#c428bb63ff65bdedb4a26d986ebd22e325e52b33"
+
+tachyons-utilities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tachyons-utilities/-/tachyons-utilities-2.0.0.tgz#64df9486efc432924f20fd90b8d2c0fc1c295b75"
+
+tachyons-vertical-align@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-vertical-align/-/tachyons-vertical-align-4.0.4.tgz#afe7ddbf2963cfd2094a1b4d97ad974c555cd6d7"
+
+tachyons-visibility@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-visibility/-/tachyons-visibility-2.0.4.tgz#9a6d2ac1258d28aec081935dcef626857d3cf53f"
+
+tachyons-white-space@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/tachyons-white-space/-/tachyons-white-space-4.0.5.tgz#cd51794d57ba19d3ed48d6ec2361f59edf095ecc"
+
+tachyons-widths@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tachyons-widths/-/tachyons-widths-5.1.1.tgz#abf61705b22630b9b10ce7874cddb26a5c01b023"
+
+tachyons-word-break@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tachyons-word-break/-/tachyons-word-break-3.0.4.tgz#242fef58c1650b998834ca5f67f21fff56ffa118"
+
+tachyons-z-index@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/tachyons-z-index/-/tachyons-z-index-1.0.8.tgz#a853254917c9902ca2393da44ed2c093f148cbad"
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-abab@^1.0.0:
+abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
 
@@ -17,29 +17,25 @@ accepts@~1.3.3:
     mime-types "~2.1.11"
     negotiator "0.6.1"
 
-acorn-globals@^1.0.4:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-1.0.9.tgz#55bb5e98691507b74579d0513413217c380c54cf"
+acorn-globals@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
   dependencies:
-    acorn "^2.1.0"
+    acorn "^4.0.4"
 
-acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
+acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
   dependencies:
     acorn "^3.0.4"
 
-acorn@^2.1.0, acorn@^2.4.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
+acorn@4.0.4, acorn@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
 acorn@^3.0.0, acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-
-acorn@^4.0.1:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.5.tgz#d5c76ef581c59748047067e2fc96302b1333c132"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -102,8 +98,8 @@ append-transform@^0.4.0:
     default-require-extensions "^1.0.0"
 
 aproba@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.0.4.tgz#2713680775e7614c8ba186c065d4e2e52d1072c0"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.1.tgz#95d3600f07710aa0e9298c726ad5ecf2eacbabab"
 
 are-we-there-yet@~1.1.2:
   version "1.1.2"
@@ -222,8 +218,8 @@ aws-sign2@~0.6.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
 aws4@^1.2.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
 axios@^0.15.3:
   version "0.15.3"
@@ -900,14 +896,14 @@ babel-register@^6.16.0, babel-register@^6.22.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@6.11.6, babel-runtime@^6.9.1:
+babel-runtime@6.11.6:
   version "6.11.6"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.11.6.tgz#6db707fef2d49c49bfa3cb64efdb436b518b8222"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.9.5"
 
-babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.9.0:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.22.0.tgz#1cf8b4ac67c77a4ddb0db2ae1f74de52ac4ca611"
   dependencies:
@@ -1112,8 +1108,8 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.3.0"
 
 caniuse-db@^1.0.30000346, caniuse-db@^1.0.30000539, caniuse-db@^1.0.30000554, caniuse-db@^1.0.30000617:
-  version "1.0.30000619"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000619.tgz#bffaa8150637c3182d3914a9718369b079299529"
+  version "1.0.30000622"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000622.tgz#9d9690b577384990a58e33ebb903a14da735e5fd"
 
 cardinal@^1.0.0:
   version "1.0.0"
@@ -1181,8 +1177,8 @@ classnames@^2.2.0, classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
 clean-css@4.0.x:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.0.3.tgz#9da7b59301d940c345757f175e6dfa6872c7de8e"
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.0.5.tgz#6a48c30dad03ebe425d209fc282baa53d36c92ca"
   dependencies:
     source-map "0.5.x"
 
@@ -1523,11 +1519,11 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-cssom@0.3.x, "cssom@>= 0.3.0 < 0.4.0":
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.2.36 < 0.3.0":
+"cssstyle@>= 0.2.37 < 0.3.0":
   version "0.2.37"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
@@ -1708,8 +1704,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.2.1.tgz#63ac7579a1c5bedb296c8607621f2efc9a54b968"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.2.2.tgz#e41bc9488c88e3cfa1e94bde28e8420d7d47c47c"
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -1931,15 +1927,19 @@ eslint@3.8.1:
     user-home "^2.0.0"
 
 espree@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.3.2.tgz#dbf3fadeb4ecb4d4778303e50103b3d36c88b89c"
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.0.tgz#41656fa5628e042878025ef467e78f125cb86e1d"
   dependencies:
-    acorn "^4.0.1"
+    acorn "4.0.4"
     acorn-jsx "^3.0.0"
 
 esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+
+esprima@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esprima@~3.0.0:
   version "3.0.0"
@@ -2222,8 +2222,8 @@ form-data@~2.1.1:
     mime-types "^2.1.12"
 
 format-number@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/format-number/-/format-number-2.0.1.tgz#e9231a8743ca64b47d09555dce40296343be66eb"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/format-number/-/format-number-2.0.2.tgz#8be2aa6fa6ef5ec43830892b1daee72705f9b462"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -2276,8 +2276,8 @@ function-bind@^1.0.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
 gauge@~2.7.1:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.2.tgz#15cecc31b02d05345a5d6b0e171cdb3ad2307774"
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.3.tgz#1c23855f962f17b3ad3d0dc7443f304542edfe09"
   dependencies:
     aproba "^1.0.3"
     console-control-strings "^1.0.0"
@@ -2286,7 +2286,6 @@ gauge@~2.7.1:
     signal-exit "^3.0.0"
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
-    supports-color "^0.2.0"
     wide-align "^1.1.0"
 
 generate-function@^2.0.0:
@@ -2454,8 +2453,8 @@ honeybadger-js@^0.4.3:
   resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-0.4.3.tgz#624796f10c92074ea4e8cd91751e062f4a942191"
 
 hosted-git-info@^2.1.4:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.2.0.tgz#7a0d097863d886c0fabbdcd37bf1758d8becf8a5"
 
 html-comment-regex@^1.1.0:
   version "1.1.1"
@@ -2472,8 +2471,8 @@ html-entities@1.2.0:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.0.tgz#41948caf85ce82fed36e4e6a0ed371a6664379e2"
 
 html-minifier@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.3.0.tgz#a9b5b8eda501362d4c5699db02a8dc72013d1fab"
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.3.1.tgz#dd38e60571537bf34a8171889c64fce73c45edad"
   dependencies:
     camel-case "3.0.x"
     clean-css "4.0.x"
@@ -2544,7 +2543,7 @@ iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@^0.4.13, iconv-lite@~0.4.13:
+iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
@@ -3089,7 +3088,14 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@3.x, js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0, js-yaml@~3.7.0:
+js-yaml@3.x, js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.1.tgz#782ba50200be7b9e5a8537001b7804db3ad02628"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^3.1.1"
+
+js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -3101,29 +3107,28 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
 
 jsdom@^9.8.1:
-  version "9.9.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.9.1.tgz#84f3972ad394ab963233af8725211bce4d01bfd5"
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.10.0.tgz#72d04d9fd5f1164d016dc350ef889af6d0d1a25a"
   dependencies:
-    abab "^1.0.0"
-    acorn "^2.4.0"
-    acorn-globals "^1.0.4"
+    abab "^1.0.3"
+    acorn "^4.0.4"
+    acorn-globals "^3.1.0"
     array-equal "^1.0.0"
     content-type-parser "^1.0.1"
-    cssom ">= 0.3.0 < 0.4.0"
-    cssstyle ">= 0.2.36 < 0.3.0"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle ">= 0.2.37 < 0.3.0"
     escodegen "^1.6.1"
     html-encoding-sniffer "^1.0.1"
-    iconv-lite "^0.4.13"
     nwmatcher ">= 1.3.9 < 2.0.0"
     parse5 "^1.5.1"
-    request "^2.55.0"
-    sax "^1.1.4"
-    symbol-tree ">= 3.1.0 < 4.0.0"
-    tough-cookie "^2.3.1"
+    request "^2.79.0"
+    sax "^1.2.1"
+    symbol-tree "^3.2.1"
+    tough-cookie "^2.3.2"
     webidl-conversions "^3.0.1"
     whatwg-encoding "^1.0.1"
-    whatwg-url "^4.1.0"
-    xml-name-validator ">= 2.0.1 < 3.0.0"
+    whatwg-url "^4.3.0"
+    xml-name-validator "^2.0.1"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -3186,10 +3191,9 @@ jsprim@^1.2.2:
     verror "1.3.6"
 
 jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.1:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.3.5.tgz#9ba6297198d9f754594d62e59496ffb923778dd4"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz#5afe38868f56bc8cc7aeaef0100ba8c75bd12591"
   dependencies:
-    acorn-jsx "^3.0.1"
     object-assign "^4.1.0"
 
 jwt-simple@^0.5.1:
@@ -3883,16 +3887,16 @@ postcss-calc@^5.2.0:
     reduce-css-calc "^1.2.6"
 
 postcss-colormin@^2.1.8:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-2.2.1.tgz#dc5421b6ae6f779ef6bfd47352b94abe59d0316b"
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-2.2.2.tgz#6631417d5f0e909a3d7ec26b24c8a8d1e4f96e4b"
   dependencies:
     colormin "^1.0.5"
     postcss "^5.0.13"
     postcss-value-parser "^3.2.3"
 
 postcss-convert-values@^2.3.4:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-2.6.0.tgz#08c6d06130fe58a91a21ff50829e1aad6a3a1acc"
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz#bbd8593c5c1fd2e3d1c322bb925dcae8dae4d62d"
   dependencies:
     postcss "^5.0.11"
     postcss-value-parser "^3.1.2"
@@ -4136,8 +4140,8 @@ postcss-zindex@^2.0.1:
     uniqs "^2.0.0"
 
 postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.4:
-  version "5.2.11"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.11.tgz#ff29bcd6d2efb98bfe08a022055ec599bbe7b761"
+  version "5.2.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.12.tgz#6a2b15e35dd65634441bb0961fa796904c7890e0"
   dependencies:
     chalk "^1.1.3"
     js-base64 "^2.1.9"
@@ -4168,8 +4172,8 @@ pretty-format@~4.2.1:
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-4.2.3.tgz#8894c2ac81419cf801629d8f66320a25380d8b05"
 
 private@^0.1.6, private@~0.1.5:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/private/-/private-0.1.6.tgz#55c6a976d0f9bafb9924851350fe47b9b5fbb7c1"
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -4553,7 +4557,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.55.0, request@^2.79.0:
+request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -4661,9 +4665,9 @@ sane@~1.4.1:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sax@^1.1.4, sax@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+sax@^1.2.1, sax@~1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
@@ -4929,10 +4933,6 @@ style-loader@0.13.1:
   dependencies:
     loader-utils "^0.2.7"
 
-supports-color@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
-
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -4955,7 +4955,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-"symbol-tree@>= 3.1.0 < 4.0.0":
+symbol-tree@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.1.tgz#8549dd1d01fa9f893c18cc9ab0b106b4d9b168cb"
 
@@ -5046,9 +5046,9 @@ tachyons-display@^5.0.3:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/tachyons-display/-/tachyons-display-5.0.4.tgz#9ec6918b0695753b7c296c0a1275c8b214b25b9a"
 
-tachyons-egghead@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tachyons-egghead/-/tachyons-egghead-1.2.0.tgz#19b14d42ad9e790565898f23a5e41965c75a5fda"
+tachyons-egghead@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/tachyons-egghead/-/tachyons-egghead-1.2.1.tgz#191488e6d7e95340ec2e8139a8062d3f20736f76"
   dependencies:
     normalize.css "^5.0.0"
     tachyons-aspect-ratios "^1.0.1"
@@ -5330,7 +5330,7 @@ toposort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.2.tgz#be1de72431320fcefe35a7b539c1c336cbcfd32c"
 
-tough-cookie@^2.3.1, tough-cookie@~2.3.0:
+tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
@@ -5627,7 +5627,7 @@ whatwg-fetch@1.0.0, whatwg-fetch@>=0.10.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz#01c2ac4df40e236aaa18480e3be74bd5c8eb798e"
 
-whatwg-url@^4.1.0:
+whatwg-url@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.3.0.tgz#92aaee21f4f2a642074357d70ef8500a7cbb171a"
   dependencies:
@@ -5698,7 +5698,7 @@ xml-char-classes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
 
-"xml-name-validator@>= 2.0.1 < 3.0.0":
+xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 


### PR DESCRIPTION
# Changes

- Replace default `tachyons` with `tachyons-egghead`
- Add `tachyons-egghead` classes to better match styleguide mocks

This is just a first pass; still some things that need to be tweaked and still need to pull in `egghead-ui` components to replace the local versions. @tayiorbeii and I plan to do this together.

# Result For User

![tachyons-egghead](https://cloud.githubusercontent.com/assets/5497885/22843299/1dd264f6-ef96-11e6-88b9-3eef63576f18.gif)

---

![](https://media.giphy.com/media/12NUbkX6p4xOO4/giphy.gif)