### PR TITLE
Remove current month from total revenue

### DIFF
--- a/src/screens/Overview/components/Stats/index.js
+++ b/src/screens/Overview/components/Stats/index.js
@@ -9,6 +9,7 @@ import {
 import {Heading} from 'egghead-ui'
 import currentMonthStart from './utils/currentMonthStart'
 import totalRevenue from './utils/totalRevenue'
+import removeCurrentMonth from './utils/removeCurrentMonth'
 import IconLabel from './components/IconLabel'
 import RevenuePeriod from './components/RevenuePeriod'
 
@@ -16,7 +17,7 @@ export default ({instructor}) => {
 
   const {revenue, published_courses, published_lessons} = instructor
   const currentMonthRevenue = find(revenue, ['month', currentMonthStart()])
-  const currentTotalRevenue = totalRevenue(revenue)
+  const currentTotalRevenue = totalRevenue(removeCurrentMonth(revenue, currentMonthStart()))
 
   return(
     <div>

--- a/src/screens/Overview/components/Stats/utils/removeCurrentMonth/index.js
+++ b/src/screens/Overview/components/Stats/utils/removeCurrentMonth/index.js
@@ -1,0 +1,3 @@
+import {filter} from 'lodash'
+
+export default (revenue, month) => filter(revenue, (memo) => memo.month !==  month)

--- a/src/screens/Overview/components/Stats/utils/removeCurrentMonth/index.test.js
+++ b/src/screens/Overview/components/Stats/utils/removeCurrentMonth/index.test.js
@@ -1,0 +1,34 @@
+import removeCurrentMonth from '.'
+
+const revenueFixture = [
+  {
+    month: '2016-02-01',
+    minutes_watched: 5,
+    revenue: 2,
+  },
+  {
+    month: '2016-03-01',
+    minutes_watched: 15,
+    revenue: 3,
+  },
+  {
+    month: '2016-04-01',
+    minutes_watched: 30,
+    revenue: 5,
+  },
+]
+
+test('total revenue', () => (
+  expect(removeCurrentMonth(revenueFixture, '2016-04-01')).toEqual([
+    {
+      month: '2016-02-01',
+      minutes_watched: 5,
+      revenue: 2,
+    },
+    {
+      month: '2016-03-01',
+      minutes_watched: 15,
+      revenue: 3,
+    },
+  ])
+))


### PR DESCRIPTION
Wasn't sure if this was a bug or not, but current month revenue is included in the Previous 6 Months. Wasn't sure if we wanted to keep these separate or not.

Accept, decline, whatever.