### PR TITLE
moves actions to the lesson teaser widget used in list

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
-REACT_APP_EGGHEAD_BASE_URL=https://egghead-io-staging.com
+# REACT_APP_EGGHEAD_BASE_URL=https://egghead-io-staging.com
 # REACT_APP_EGGHEAD_BASE_URL=http://egghead.dev:5000
+REACT_APP_EGGHEAD_BASE_URL=https://egghead.io

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # REACT_APP_EGGHEAD_BASE_URL=https://egghead-io-staging.com
-# REACT_APP_EGGHEAD_BASE_URL=http://egghead.dev:5000
-REACT_APP_EGGHEAD_BASE_URL=https://egghead.io
+REACT_APP_EGGHEAD_BASE_URL=http://egghead.dev:5000
+# REACT_APP_EGGHEAD_BASE_URL=https://egghead.io

--- a/src/components/LessonList/components/PaginatedLessonList/components/LessonTeaser/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/components/LessonTeaser/index.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
-import {Button, Heading} from 'egghead-ui'
-import {viewActionText} from 'utils/text'
-import {statusByLessonState} from 'utils/lessonStates'
+import {Heading} from 'egghead-ui'
 import {Markdown} from 'egghead-ui'
+import LessonNextSteps from 'components/LessonNextSteps'
 
 export default ({instructor, lesson}) => {
 
@@ -17,35 +16,24 @@ export default ({instructor, lesson}) => {
       />
 
       <div>
-        <Heading level='5'>
-          {lesson.title}
-        </Heading>
-        <div className={`
-          mb2 ttu tc pa1 br2 ba f6 dib
-          ${statusByLessonState[lesson.state].requiresUserAction
-            ? 'blue b--blue'
-            : 'yellow b--yellow'
-          }
-        `}>
-          {lesson.state}
-        </div>
-        <div style={{
+        <Link to={`/lessons/${lesson.slug}`}>
+          <Heading level='3'>
+            {lesson.title}
+          </Heading>
+        </Link>
+        <div className='mt4 white-80' style={{
           wordBreak: 'break-word',
         }}>
           {lesson.summary
             ? <Markdown>
-                {lesson.summary}
-              </Markdown>
+            {lesson.summary}
+          </Markdown>
             : null
           }
         </div>
-        <div className='mt2'>
-          <Link to={`/lessons/${lesson.slug}`}>
-            <Button size='extra-small'>
-              {viewActionText}
-            </Button>
-          </Link>
-        </div>
+        <LessonNextSteps lesson={lesson}/>
+
+
       </div>
 
     </div>

--- a/src/components/LessonNextSteps/index.js
+++ b/src/components/LessonNextSteps/index.js
@@ -7,17 +7,13 @@ import WrappedRequest from 'components/WrappedRequest'
 
 export default ({lesson}) => (
   <div>
-
-      <Heading level='3'>
-        {statusTitleText}
-      </Heading>
       <div className={`
         mb3 ttu tc pv2 ph3 br2 ba b--dashed dib
         ${statusByLessonState[lesson.state].requiresUserAction ? 'blue b--blue' : 'yellow b--yellow'}
       `}>
         {lesson.state}
       </div>
-      <div>
+      <div className="white-50">
         {statusByLessonState[lesson.state].description}
       </div>
 

--- a/src/components/LessonNextSteps/index.js
+++ b/src/components/LessonNextSteps/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import {map, keys} from 'lodash'
-import {Button, Heading} from 'egghead-ui'
-import {statusTitleText} from 'utils/text'
+import {Button} from 'egghead-ui'
 import {statusByLessonState, actionByLessonState} from 'utils/lessonStates'
 import WrappedRequest from 'components/WrappedRequest'
 

--- a/src/screens/Lessons/screens/Lesson/index.js
+++ b/src/screens/Lessons/screens/Lesson/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Screen from 'components/Screen'
-import LessonNextSteps from './components/LessonNextSteps'
+import LessonNextSteps from 'components/LessonNextSteps'
 import LessonData from './components/LessonData'
 import WistiaVideo from './components/WistiaVideo'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,9 +2189,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-egghead-ui@^2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/egghead-ui/-/egghead-ui-2.23.0.tgz#c887bf1098a149f84b7596d639e9cf19f50af03d"
+egghead-ui@^2.25.0:
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/egghead-ui/-/egghead-ui-2.25.0.tgz#0e00c813fd29a7787e8af2ce76b585001dd82c0e"
   dependencies:
     "@kadira/react-storybook-addon-info" "^3.3.0"
     "@kadira/storybook" "^2.5.2"
@@ -2201,6 +2201,7 @@ egghead-ui@^2.23.0:
     babel-preset-latest "^6.22.0"
     babel-preset-react "^6.22.0"
     eslint "^3.16.1"
+    eslint-config-keystone "^3.0.0"
     font-awesome "^4.6.3"
     lodash "^4.16.2"
     pre-commit "^1.2.2"
@@ -2363,6 +2364,10 @@ escope@^3.6.0:
     es6-weak-map "^2.0.1"
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eslint-config-keystone@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-keystone/-/eslint-config-keystone-3.0.0.tgz#28d6323491a95cc738613c0ac2a7b73936eb5332"
 
 eslint-config-react-app@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
Wanted to move the "action"" buttons for state transitions into the lesson teaser. The "teaser" is a little "plump", but I'm cool with that for now. It has a lot of utility for instructors and editors.

We might consider adding confirmations to destructive actions, and it'd be nice to give some color and separation to the buttons perhaps.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/35471P1T373P2a2p3j2O/Screen%20Recording%202017-03-07%20at%2010.58%20AM.gif?v=693f13a4)

![](https://media.giphy.com/media/KMyoccbYZle9O/giphy.gif)