### PR TITLE
destructure LessonNextSteps for versatility

### DIFF
--- a/src/components/LessonList/components/PaginatedLessonList/components/LessonTeaser/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/components/LessonTeaser/index.js
@@ -3,6 +3,8 @@ import {Link} from 'react-router-dom'
 import {Heading} from 'egghead-ui'
 import {Markdown} from 'egghead-ui'
 import LessonNextSteps from 'components/LessonNextSteps'
+import LessonUploadEdit from 'components/LessonUploadEdit'
+import LessonStatus from 'components/LessonStatus'
 
 export default ({instructor, lesson}) => {
 
@@ -31,9 +33,13 @@ export default ({instructor, lesson}) => {
             : null
           }
         </div>
+        <LessonStatus lesson={lesson}/>
+        <div className="mt3">
+        <LessonUploadEdit lesson={lesson}/>
+        </div>
+        <div className="mt1">
         <LessonNextSteps lesson={lesson}/>
-
-
+        </div>
       </div>
 
     </div>

--- a/src/components/LessonNextSteps/index.js
+++ b/src/components/LessonNextSteps/index.js
@@ -1,22 +1,14 @@
 import React from 'react'
 import {map, keys} from 'lodash'
 import {Button} from 'egghead-ui'
-import {statusByLessonState, actionByLessonState} from 'utils/lessonStates'
+import {actionByLessonState, colorByLessonState} from 'utils/lessonStates'
+
+
 import WrappedRequest from 'components/WrappedRequest'
 
 export default ({lesson}) => (
   <div>
-      <div className={`
-        mb3 ttu tc pv2 ph3 br2 ba b--dashed dib
-        ${statusByLessonState[lesson.state].requiresUserAction ? 'blue b--blue' : 'yellow b--yellow'}
-      `}>
-        {lesson.state}
-      </div>
-      <div className="white-50">
-        {statusByLessonState[lesson.state].description}
-      </div>
-
-      <div className='flex flex-wrap mt3'>
+      <div className='flex flex-wrap'>
         {map(keys(actionByLessonState), (state, index) => {
           const stateUrl = lesson[`${state}_url`]
           return stateUrl
@@ -31,6 +23,7 @@ export default ({lesson}) => (
                     <Button
                       size='extra-small'
                       onClick={() => request()}
+                      color={colorByLessonState[state].color}
                     >
                       {actionByLessonState[state].title}
                     </Button>

--- a/src/components/LessonStatus/index.js
+++ b/src/components/LessonStatus/index.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import {statusByLessonState} from 'utils/lessonStates'
+
+export default function LessonStatus({lesson}) {
+  return (
+    <div>
+      <div className={`
+        mb3 ttu tc pv2 ph3 br2 ba b--dashed dib
+        ${statusByLessonState[lesson.state].requiresUserAction ? 'blue b--blue' : 'yellow b--yellow'}
+      `}>
+        {lesson.state}
+      </div>
+      <div className="white-50">
+        {statusByLessonState[lesson.state].description}
+      </div>
+    </div>
+  )
+}

--- a/src/components/LessonUploadEdit/index.js
+++ b/src/components/LessonUploadEdit/index.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import {
+  uploadVideoTitleText,
+  editLessonTitleText,
+  replaceVideoTitleText,
+} from 'utils/text'
+import Anchor from 'components/Anchor'
+import {Button} from 'egghead-ui'
+
+export default function LessonUploadEdit ({lesson}) {
+  return (
+    <span>
+    <div className='flex mb3'>
+    {
+      lesson.edit_lesson_http_url ?
+        <div className="pa1">
+          <Anchor url={lesson.edit_lesson_http_url}>
+            <Button color='blue' size='extra-small'>
+              {editLessonTitleText}
+            </Button>
+          </Anchor>
+        </div>
+        : null
+    }
+      {
+        lesson.upload_lesson_http_url ?
+          <div className="pa1">
+            <Anchor url={lesson.upload_lesson_http_url}>
+              <Button color='blue' size='extra-small'>
+                {`${lesson.wistia_id ? replaceVideoTitleText : uploadVideoTitleText} Video`}
+              </Button>
+            </Anchor>
+          </div>
+          : null
+      }
+    </div>
+  </span>
+  )
+}

--- a/src/screens/Lessons/screens/Lesson/components/LessonData/index.js
+++ b/src/screens/Lessons/screens/Lesson/components/LessonData/index.js
@@ -1,21 +1,15 @@
 import React from 'react'
 import {map, size} from 'lodash'
-import {Button} from 'egghead-ui'
 import {
   instructorTitleText,
   technologyTitleText,
   summaryTitleText,
-  uploadVideoTitleText,
-  editLessonTitleText,
-  replaceVideoTitleText,
 } from 'utils/text'
-import Anchor from 'components/Anchor'
+import LessonUploadEdit from 'components/LessonUploadEdit'
 import Avatar from 'components/Avatar'
 import {Markdown} from 'egghead-ui'
 
 export default ({instructor, lesson}) => {
-
-  const hasVideo = lesson.wistia_id
 
   const items = [
     {
@@ -74,22 +68,7 @@ export default ({instructor, lesson}) => {
           </div>
         ))}
       </div>
-
-      {lesson.edit_lesson_http_url
-        ? <div className='mb3'>
-            <Anchor url={lesson.edit_lesson_http_url} className='ma1'>
-              <Button color='blue' size='extra-small'>
-                {hasVideo ? editLessonTitleText : `${editLessonTitleText}`}
-              </Button>
-            </Anchor>
-            <Anchor url={lesson.upload_lesson_http_url} className='ma1'>
-              <Button color='blue' size='extra-small'>
-                {hasVideo ? replaceVideoTitleText : uploadVideoTitleText} Video
-              </Button>
-            </Anchor>
-          </div>
-        : null
-      }
+      <LessonUploadEdit lesson={lesson} />
     </div>
   )
 }

--- a/src/screens/Lessons/screens/Lesson/index.js
+++ b/src/screens/Lessons/screens/Lesson/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Screen from 'components/Screen'
 import LessonNextSteps from 'components/LessonNextSteps'
+import LessonStatus from 'components/LessonStatus'
 import LessonData from './components/LessonData'
 import WistiaVideo from './components/WistiaVideo'
 
@@ -21,7 +22,12 @@ export default ({instructor, lesson}) => (
 
       }
       aside={
-        <LessonNextSteps lesson={lesson}/>
+        <div>
+          <LessonStatus lesson={lesson}/>
+          <div className="mt3">
+            <LessonNextSteps lesson={lesson}/>
+          </div>
+        </div>
       }
     />
   </div>

--- a/src/utils/lessonStates/index.js
+++ b/src/utils/lessonStates/index.js
@@ -142,3 +142,42 @@ export const actionByLessonState = {
     title: retireActionText,
   },
 }
+
+export const colorByLessonState = {
+  cancel: {
+    color: 'red',
+  },
+  accept: {
+    color: 'green',
+  },
+  request: {
+    color: 'white',
+  },
+  claim: {
+    color: 'green',
+  },
+  submit: {
+    color: 'green',
+  },
+  reject: {
+    color: 'orange',
+  },
+  apply_update: {
+    color: 'green',
+  },
+  approve: {
+    color: 'green',
+  },
+  publish: {
+    color: 'green',
+  },
+  flag: {
+    color: 'orange',
+  },
+  revise: {
+    color: 'green',
+  },
+  retire: {
+    color: 'red',
+  },
+}

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -133,16 +133,16 @@ export const logOutTitleText = 'Log out'
 
 export const proposedStateDescriptionText = `This lesson is proposed. Waiting for approval.`
 export const cancelledStateDescriptionText = `This lesson has been cancelled.`
-export const acceptedStateDescriptionText = `This lesson has been accepted - it's just waiting to be claimed.`
-export const requestedStateDescriptionText = `This lesson has been requested - it's just waiting to be claimed.`
-export const claimedStateDescriptionText = `This lesson is claimed - it's just waiting for a a video to be submitted.`
-export const submittedStateDescriptionText = 'Sweet! This lesson has been submitted and is waiting for approval.'
-export const rejectedStateDescriptionText = 'This lesson needs updated based on feedback received.'
-export const updatedStateDescriptionText = 'Lesson updated! Waiting for approval.'
-export const approvedStateDescriptionText = 'This lesson has been approved and is in the publishing queue.'
-export const publishedStateDescriptionText = `This lesson has been published. What's next?`
+export const acceptedStateDescriptionText = `This lesson has been accepted - it can be claimed.`
+export const requestedStateDescriptionText = `This lesson has been requested - it can be claimed.`
+export const claimedStateDescriptionText = `This lesson is claimed. Now it needs a video to be added.`
+export const submittedStateDescriptionText = 'Sweet! This lesson is waiting for review.'
+export const rejectedStateDescriptionText = 'This lesson is waiting for an updated video.'
+export const updatedStateDescriptionText = 'Lesson updated! Waiting for review.'
+export const approvedStateDescriptionText = 'This lesson is approved and is in line for publication.'
+export const publishedStateDescriptionText = `This lesson has been published. `
 export const flaggedStateDescriptionText = `This lesson has been flagged - it needs some changes.`
-export const revisedStateDescriptionText = `This lesson has revised. Waiting for approval.`
+export const revisedStateDescriptionText = `This lesson has revised and is waiting for review.`
 export const retiredStateDescriptionText = `This lesson has been retired.`
 
 export const proposeActionText = `Propose`


### PR DESCRIPTION
This breaks LessonNextSteps apart so that the status of a lesson is its own component, and next steps is strictly concerned with actions. Also added some colors for buttons and modified some text.

The LessonTeaser needs lots of design love. Was thinking about that here: https://paper.dropbox.com/doc/Lists-of-Lessons-LOL-hkj93JkuRH5ggz45BHrvJ

![image](https://cloud.githubusercontent.com/assets/86834/23683698/4299c762-034f-11e7-8f7d-ae47df923107.png)

![image](https://cloud.githubusercontent.com/assets/86834/23683713/5568dab8-034f-11e7-8fed-a6ea72d37529.png)

![](https://media.giphy.com/media/11aCNnhizTWfXW/giphy.gif)