### PR TITLE
Fix stat icons

### DIFF
--- a/src/screens/Instructors/screens/Instructor/components/Stats/components/RevenuePeriod/index.js
+++ b/src/screens/Instructors/screens/Instructor/components/Stats/components/RevenuePeriod/index.js
@@ -10,11 +10,11 @@ export default ({title, revenue, subscriberMinutes}) => (
       {title}
     </Heading>
     <IconLabel
-      iconType='revenue'
+      iconType='dollar'
       labelText={formatNumber({round: 2, prefix: '$', padRight: 2})(revenue)}
     />
     <IconLabel
-      iconType='subscriber-minutes'
+      iconType='clock'
       labelText={`${formatNumber({round: 2})(subscriberMinutes)} ${subscriberMinutesLabelText}`}
     />
   </div>


### PR DESCRIPTION
# Changes

- Fix infinite state spinning; was trying to create an Icon svg from types that were renamed with move to svg icons in latest egghead-ui

# Result For User

Stats working again.

---

![](https://media.giphy.com/media/sE6jQonM5S8mI/source.gif)