### PR TITLE
Move .env to yarn scripts (resolve #152)

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-REACT_APP_EGGHEAD_BASE_URL=https://egghead-io-staging.com
-# REACT_APP_EGGHEAD_BASE_URL=http://egghead.dev:5000
-# REACT_APP_EGGHEAD_BASE_URL=https://egghead.io

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ _An app for egghead instructors to do instructor things_
 - Ensure you have Git, Node, and Yarn installed
 - Clone this repo and `cd` into it
 - `yarn` to install packages
+- `yarn dev` to run app with local dev endpoints ([egghead-rails needs to be running locally](https://gist.github.com/trevordmiller/35dcf0a705b8cb610178f18a135ea6e3))
+- `yarn dev:staging` to run app with staging endpoints
+- `yarn dev:prod` to run app with prod endpoints
 - `yarn test` to run tests
-- `yarn dev` to run app
 - Open [localhost:3000](http://localhost:3000) to view app
 - Log in with your egghead instructor account and testing password
 
@@ -82,14 +84,11 @@ ES2015 modules are used for sharing code between files. `NODE_PATH` is set to `s
 
 ## Environment
 
-The `.env` file is used to load environment variables. The base url of endpoint calls is set here to use different environment endpoints as well.
-
 - Staging: use staging value, no local setup needed
-- Dev: use dev value with [egghead-rails running locally](https://gist.github.com/trevordmiller/35dcf0a705b8cb610178f18a135ea6e3)
 
 ## Endpoints
 
-The [`WrappedRequest` component] extends the [`Request` component](https://styleguide.egghead.io); it is used with the `egghead-rails` rest APIs, based on the current environment set in `.env`. The endpoint data uses hypermedia (urls to make requests to for sub-data instead of placing all data inline). Response properties and hypermedia urls are only shown when the user has access to them, so all UI based on permissions can be combined without separate routes for "roles". There is no such thing as roles in this system, but what data a response has, based on the user. This means that you can do something like `lesson.approve_url ? <ApproveButton /> : null` to show a lesson approval button and it will work for all users, regardless of their permissions.
+The [`WrappedRequest` component] extends the [`Request` component](https://styleguide.egghead.io); it is used with the `egghead-rails` rest APIs, based on the current environment. The endpoint data uses hypermedia (urls to make requests to for sub-data instead of placing all data inline). Response properties and hypermedia urls are only shown when the user has access to them, so all UI based on permissions can be combined without separate routes for "roles". There is no such thing as roles in this system, but what data a response has, based on the user. This means that you can do something like `lesson.approve_url ? <ApproveButton /> : null` to show a lesson approval button and it will work for all users, regardless of their permissions.
 
 ## Public folder
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "egghead-instructor-center",
   "version": "1.0.0",
   "scripts": {
-    "dev": "NODE_PATH=./src react-scripts start",
+    "dev": "REACT_APP_EGGHEAD_BASE_URL=http://egghead.dev:5000 NODE_PATH=./src react-scripts start",
+    "dev:staging": "REACT_APP_EGGHEAD_BASE_URL=https://egghead-io-staging.com NODE_PATH=./src react-scripts start",
+    "dev:prod": "REACT_APP_EGGHEAD_BASE_URL=https://egghead.io NODE_PATH=./src react-scripts start",
     "test": "NODE_PATH=./src react-scripts test --env=jsdom",
-    "build": "NODE_PATH=./src react-scripts build",
+    "build": "REACT_APP_EGGHEAD_BASE_URL=https://egghead.io NODE_PATH=./src react-scripts build",
     "verify": "CI=true yarn test && yarn build"
   },
   "pre-commit": [


### PR DESCRIPTION
# Changes

- Add yarn scripts for developing by environment (`yarn dev` for local dev, `yarn dev:staging` for staging, and `yarn dev:prod` for prod)
- Remove .env
- Update README to match

# Result For User

Here are the new getting started instructions in the README, no local environment files or templates required:

- Ensure you have Git, Node, and Yarn installed
- Clone this repo and `cd` into it
- `yarn` to install packages
- `yarn dev` to run app with local dev endpoints ([egghead-rails needs to be running locally](https://gist.github.com/trevordmiller/35dcf0a705b8cb610178f18a135ea6e3))
- `yarn dev:staging` to run app with staging endpoints
- `yarn dev:prod` to run app with prod endpoints
- `yarn test` to run tests
- Open [localhost:3000](http://localhost:3000) to view app
- Log in with your egghead instructor account and testing password

---

![](https://media.giphy.com/media/y4dfjHr6NsjsY/giphy.gif)