### PR TITLE
add instructor heads and don't show the instructor on 'requested' lessons

### DIFF
--- a/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
@@ -4,8 +4,9 @@ import {Heading, Markdown} from 'egghead-ui'
 import LessonState from 'components/LessonState'
 import LessonActions from 'components/LessonActions'
 
-export default ({instructor, lesson}) => {
-
+export default ({lesson}) => {
+  const {instructor} = lesson
+  const stateIsRequested = lesson.state === 'requested'
   return (
     <div className='flex items-start'>
 
@@ -23,8 +24,17 @@ export default ({instructor, lesson}) => {
           </Heading>
         </Link>
 
+        {stateIsRequested ? null :
+          <Link to={`/instructors/${instructor.slug}`} className="no-underline">
+            <div className='mb43 flex items-center pt1'>
+              <img src={instructor.avatar_url} alt={instructor.full_name} className='w2 h2 br-pill mr3'/>
+              <span className='f6 o-50 dark-gray ttc'>{instructor.full_name}</span>
+            </div>
+          </Link>
+        }
+
         <div
-          className='mt4'
+          className='mt2'
           style={{
             wordBreak: 'break-word',
           }}

--- a/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
@@ -26,7 +26,7 @@ export default ({lesson}) => {
 
         {stateIsRequested ? null :
           <Link to={`/instructors/${instructor.slug}`} className="no-underline">
-            <div className='mb43 flex items-center pt1'>
+            <div className='flex items-center pt1'>
               <img src={instructor.avatar_url} alt={instructor.full_name} className='w2 h2 br-pill mr3'/>
               <span className='f6 o-50 dark-gray ttc'>{instructor.full_name}</span>
             </div>

--- a/src/components/LessonList/components/PaginatedLessonList/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/index.js
@@ -26,7 +26,7 @@ const PaginatedLessonList = ({
   return total > 0
     ? <div>
 
-        <List items={map(sortLessonsByState(lessons), (lesson, index) => (
+        <List items={map(sortLessonsByState(lessons), (lesson) => (
           <LessonListItem 
             key={lesson.slug}
             lesson={lesson}

--- a/src/components/LessonList/components/PaginatedLessonList/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/index.js
@@ -28,7 +28,7 @@ const PaginatedLessonList = ({
 
         <List items={map(sortLessonsByState(lessons), (lesson, index) => (
           <LessonListItem 
-            key={index}
+            key={lesson.slug}
             lesson={lesson}
           />
         ))} />

--- a/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
+++ b/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {map} from 'lodash'
+import {map, compact} from 'lodash'
 import {Markdown, Heading} from 'egghead-ui'
 import {
   videoTitleText,
@@ -16,9 +16,9 @@ import LessonActions from 'components/LessonActions'
 import Avatar from 'components/Avatar'
 import WistiaVideo from './components/WistiaVideo'
 
-export default ({instructor, lesson}) => {
+export default ({lesson}) => {
 
-  const items = [
+  const items = compact([
     {
       title: videoTitleText,
       children: (
@@ -40,7 +40,7 @@ export default ({instructor, lesson}) => {
         <LessonActions lesson={lesson} />
       ),
     },
-    {
+    lesson.state === 'requested' ? {
       title: instructorTitleText,
       children: (
         <div className='flex items-center'>
@@ -54,7 +54,7 @@ export default ({instructor, lesson}) => {
           {lesson.instructor.full_name}
         </div>
       ),
-    },
+    } : null,
     {
       title: technologyTitleText,
       children: (
@@ -76,7 +76,7 @@ export default ({instructor, lesson}) => {
         </Markdown>
       ),
     },
-  ]
+  ])
 
   return (
     <Card title={lesson.title}>


### PR DESCRIPTION
(resolves #160)

![](https://d3vv6lp55qjaqc.cloudfront.net/items/0c0L1L0l1F1p1l2h3S3n/Screen%20Recording%202017-03-15%20at%2005.19%20PM.gif?v=a8fee2bb)

technically a requested lesson shouldn't have an instructor, so we want to hide it if they are in this state. We could show the **creator**, but that is less useful anyway.

![](https://media.giphy.com/media/GA2dwDU7owOS4/giphy.gif)