### PR TITLE
Add client side updates (resolve #147)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-scripts": "^0.8.4"
   },
   "dependencies": {
-    "egghead-ui": "^3.1.7",
+    "egghead-ui": "^3.2.0",
     "format-number": "^2.0.1",
     "honeybadger-js": "^0.4.3",
     "jwt-simple": "^0.5.1",

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -3,9 +3,12 @@ import {Heading, Paragraph} from 'egghead-ui'
 
 export default ({children, title, description}) => (
   <section className='mb4'>
-    <Heading level='4'>
-      {title}
-    </Heading>
+    {title
+      ? <Heading level='4'>
+          {title}
+        </Heading>
+      : null
+    }
     {description
       ? <Paragraph type='small'>
           {description}

--- a/src/components/LessonActions/components/LessonStateProgression/index.js
+++ b/src/components/LessonActions/components/LessonStateProgression/index.js
@@ -4,7 +4,7 @@ import {Button} from 'egghead-ui'
 import {lessonStateVerbToPastTense, detailsByLessonState} from 'utils/lessonStates'
 import WrappedRequest from 'components/WrappedRequest'
 
-export default ({lesson}) => (
+export default ({lesson, onLessonStateChange}) => (
   <div className='flex flex-wrap'>
     {map(keys(lessonStateVerbToPastTense), (stateVerb, index) => {
       const stateVerbUrl = lesson[`${stateVerb}_url`]
@@ -14,6 +14,7 @@ export default ({lesson}) => (
             lazy
             method='post'
             url={stateVerbUrl}
+            onResponse={onLessonStateChange}
           >
             {({request}) => (
               <div className='pa1'>

--- a/src/components/LessonActions/index.js
+++ b/src/components/LessonActions/index.js
@@ -2,9 +2,12 @@ import React from 'react'
 import LessonStateProgression from './components/LessonStateProgression'
 import LessonEdit from './components/LessonEdit'
 
-export default ({lesson}) => (
+export default ({lesson, requestLesson, requestCurrentPage}) => (
   <div>
     <LessonEdit lesson={lesson} />
-    <LessonStateProgression lesson={lesson} />
+    <LessonStateProgression 
+      lesson={lesson} 
+      onLessonStateChange={requestLesson || requestCurrentPage}
+    />
   </div>
 )

--- a/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
@@ -4,7 +4,7 @@ import {Heading, Markdown} from 'egghead-ui'
 import LessonState from 'components/LessonState'
 import LessonActions from 'components/LessonActions'
 
-export default ({lesson}) => {
+export default ({lesson, requestCurrentPage}) => {
   const {instructor} = lesson
   const stateIsRequested = lesson.state === 'requested'
   return (
@@ -50,7 +50,10 @@ export default ({lesson}) => {
         <LessonState lesson={lesson}/>
 
         <div className="mt3">
-          <LessonActions lesson={lesson} />
+          <LessonActions 
+            lesson={lesson} 
+            requestCurrentPage={requestCurrentPage}
+          />
         </div>
 
       </div>

--- a/src/components/LessonList/components/PaginatedLessonList/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/index.js
@@ -13,6 +13,7 @@ const PaginatedLessonList = ({
   total,
   lessons,
   requestNextPage,
+  requestCurrentPage,
 }) => {
 
   const pageNum = Math.ceil(total / pageSize)
@@ -30,6 +31,7 @@ const PaginatedLessonList = ({
           <LessonListItem 
             key={lesson.slug}
             lesson={lesson}
+            requestCurrentPage={requestCurrentPage}
           />
         ))} />
 

--- a/src/components/LessonList/index.js
+++ b/src/components/LessonList/index.js
@@ -13,7 +13,7 @@ export default class LessonList extends Component {
   }
 
   static defaultProps = {
-    pageSize: 15,
+    pageSize: 10,
   }
 
   state = {

--- a/src/components/LessonList/index.js
+++ b/src/components/LessonList/index.js
@@ -51,6 +51,7 @@ export default class LessonList extends Component {
               this.handleCurrentPage(nextPage)
               request()
             }}
+            requestCurrentPage={request}
           />
         )}
       </WrappedRequest>

--- a/src/components/LessonList/index.js
+++ b/src/components/LessonList/index.js
@@ -38,6 +38,7 @@ export default class LessonList extends Component {
             ? instructor.lessons_url
             : false,
         })}
+        subscribe
       >
         {({request, data, response}) => (
           <PaginatedLessonList

--- a/src/index.js
+++ b/src/index.js
@@ -117,10 +117,11 @@ const App = () => {
                               url={`/api/v1/lessons/${match.params.slug}`}
                               subscribe
                             >
-                              {({data}) => (
+                              {({request, data}) => (
                                 <Lesson 
                                   instructor={instructor}
                                   lesson={data} 
+                                  requestLesson={request}
                                 />
                               )}
                             </WrappedRequest>

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,10 @@ const App = () => {
                         <Route 
                           path={`/lessons/:slug`}
                           render={({match}) => (
-                            <WrappedRequest url={`/api/v1/lessons/${match.params.slug}`}>
+                            <WrappedRequest
+                              url={`/api/v1/lessons/${match.params.slug}`}
+                              subscribe
+                            >
                               {({data}) => (
                                 <Lesson 
                                   instructor={instructor}

--- a/src/screens/Dashboard/components/GetPublishedCard/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/index.js
@@ -12,9 +12,12 @@ import isStepComplete from './utils/isStepComplete'
 import Checklist from './components/Checklist'
 
 export default ({instructor}) => instructor.published_lessons === 0
-  ? <WrappedRequest url={createLessonsUrl({
-      lessons_url: instructor.lessons_url
-    })}>
+  ? <WrappedRequest
+      url={createLessonsUrl({
+        lessons_url: instructor.lessons_url
+      })}
+      subscribe
+    >
       {({data}) => {
         const instructorLessonStates = compact(uniq(map(data, 'state')))
         return (

--- a/src/screens/Dashboard/components/InstructorRevenueCard/index.js
+++ b/src/screens/Dashboard/components/InstructorRevenueCard/index.js
@@ -13,7 +13,10 @@ import removeRevenueMonth from './utils/removeRevenueMonth'
 import RevenuePeriod from './components/RevenuePeriod'
 
 export default ({revenueUrl}) => revenueUrl
-  ? <WrappedRequest url={revenueUrl}>
+  ? <WrappedRequest
+      url={revenueUrl}
+      subscribe
+    >
       {({data}) => {
         const currentMonthRevenue = find(data, ['month', currentMonthStartDate()])
         const currentTotalRevenue = totalRevenue(removeRevenueMonth(data, currentMonthStartDate()))

--- a/src/screens/Lessons/screens/Lesson/components/LessonCard/components/WistiaVideo/index.js
+++ b/src/screens/Lessons/screens/Lesson/components/LessonCard/components/WistiaVideo/index.js
@@ -1,25 +1,35 @@
-import React from 'react'
+import React, {Component} from 'react'
 import {noVideoDescriptionText} from 'utils/text'
 import {Paragraph} from 'egghead-ui'
 
-export default ({title, wistiaId}) => wistiaId
-  ? <div className='aspect-ratio aspect-ratio--16x9'>
-      <div className='aspect-ratio--object'>
-        <iframe
-          ref={(iframe) => {
-            if (iframe) {
-              iframe.contentWindow.location.replace(`//fast.wistia.net/embed/iframe/${wistiaId}?videoFoam=true`)
-            }
-          }}
-          width='100%'
-          height='100%'
-          frameBorder='0'
-          scrolling='no'
-          allowTransparency
-          allowFullScreen
-        />
-      </div>
-    </div>
-  : <Paragraph>
-      {noVideoDescriptionText}
-    </Paragraph>
+export default class extends Component {
+
+  shouldComponentUpdate(nextProps) {
+    return this.props.wistiaId !== nextProps.wistiaId 
+  }
+
+  render() {
+    const {wistiaId} = this.props
+    return wistiaId
+      ? <div className='aspect-ratio aspect-ratio--16x9'>
+          <div className='aspect-ratio--object'>
+            <iframe
+              ref={(iframe) => {
+                if (iframe) {
+                  iframe.contentWindow.location.replace(`//fast.wistia.net/embed/iframe/${wistiaId}?videoFoam=true`)
+                }
+              }}
+              width='100%'
+              height='100%'
+              frameBorder='0'
+              scrolling='no'
+              allowTransparency
+              allowFullScreen
+            />
+          </div>
+        </div>
+      : <Paragraph>
+          {noVideoDescriptionText}
+        </Paragraph>
+  }
+}

--- a/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
+++ b/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
@@ -15,7 +15,7 @@ import LessonActions from 'components/LessonActions'
 import Avatar from 'components/Avatar'
 import WistiaVideo from './components/WistiaVideo'
 
-export default ({lesson}) => {
+export default ({lesson, requestLesson}) => {
 
   const items = compact([
     {
@@ -33,7 +33,10 @@ export default ({lesson}) => {
     {
       title: lessonActionsTitleText,
       children: (
-        <LessonActions lesson={lesson} />
+        <LessonActions 
+          lesson={lesson} 
+          requestLesson={requestLesson}
+        />
       ),
     },
     lesson.state === 'requested' ? {

--- a/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
+++ b/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
@@ -21,10 +21,7 @@ export default ({lesson}) => {
     {
       title: lesson.title,
       children: (
-        <WistiaVideo 
-          title={lesson.title}
-          wistiaId={lesson.wistia_id}
-        />
+        <WistiaVideo wistiaId={lesson.wistia_id} />
       ),
     },
     {

--- a/src/screens/Lessons/screens/Lesson/index.js
+++ b/src/screens/Lessons/screens/Lesson/index.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import LessonCard from './components/LessonCard'
 
-export default ({instructor, lesson}) => (
+export default ({instructor, lesson, requestLesson}) => (
   <div>
     <LessonCard
-      instructor={instructor}
       lesson={lesson}
+      requestLesson={requestLesson}
     />
   </div>
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,9 +2115,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-egghead-ui@^3.1.7:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/egghead-ui/-/egghead-ui-3.1.7.tgz#6276356f33a3bec7bf7cc0fb00ff5052661229b3"
+egghead-ui@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/egghead-ui/-/egghead-ui-3.2.0.tgz#a68b7a0eb320c63042ee8d8313eec75a69aa5f94"
   dependencies:
     "@kadira/storybook" "^2.5.2"
     axios "^0.15.3"


### PR DESCRIPTION
# Changes

- Update egghead-ui to get latest `<Request`, which adds `subscribe` (polling) option
- Use `subscribe` in components where data updates regularly
- Lower default page size for pagination as 15 was feeling big; 10 seems more reasonable
- Fix iframe reloading bug with polling by using `shouldComponentUpdate`
- Apply immediate client-side data updates where needed with `Request` callback (`onResponse` handler). This works well for now. It is a bit slower than a server push-based model or client-side only updates with a state management sytem, but it is simpler. If this becomes a problem, I'd recommend we upgrade to GraphQL (most likely with Relay) as it doesn't seem very difficult and has huge wins (maintains caching, requests etc. for you with declarative data fetching syntax inside the component that needs it); this seems to be a much better solution to state and data than Redux or MobX to me if/when the time comes.

# Result For User

![client-side-updates](https://cloud.githubusercontent.com/assets/5497885/24021810/667d6146-0a68-11e7-9b33-2e38406400ff.gif)

---

![](https://img.buzzfeed.com/buzzfeed-static/static/2014-07/18/8/enhanced/webdr10/anigif_enhanced-buzz-31768-1405685443-14.gif)