### PR TITLE
Remove uneeded pieces from lesson groups (resolve #183)

### DIFF
--- a/src/components/LessonGroups/index.js
+++ b/src/components/LessonGroups/index.js
@@ -1,16 +1,14 @@
 import React from 'react'
-import {map} from 'lodash'
+import {map, compact} from 'lodash'
 import {
   newLessonsActionText,
   inProgressTitleText,
   inReviewTitleText,
   inQueueTitleText,
   publishedTitleText,
-  inProgressDescriptionText,
   inReviewDescriptionText,
   selfReviewDescriptionText,
   inQueueDescriptionText,
-  publishedDescriptionText,
   noInProgressLessonsDescriptionText,
   noInReviewLessonsDescriptionText,
   noInQueueLessonsDescriptionText,
@@ -23,10 +21,9 @@ import Prompt from 'components/Prompt'
 
 export default ({instructor}) => {
 
-  const items = [
+  const items = compact([
     {
       title: inProgressTitleText,
-      description: inProgressDescriptionText,
       states: [
         'accepted',
         'claimed',
@@ -55,26 +52,30 @@ export default ({instructor}) => {
       ],
       fallbackDescription: noInQueueLessonsDescriptionText,
     },
-    {
-      title: publishedTitleText,
-      description: publishedDescriptionText,
-      states: [
-        'published',
-        'flagged',
-        'revised',
-      ],
-      fallbackDescription: noPublishedLessonsDescriptionText,
-    },
-  ]
+    instructor
+      ? null
+      : {
+          title: publishedTitleText,
+          states: [
+            'published',
+            'flagged',
+            'revised',
+          ],
+          fallbackDescription: noPublishedLessonsDescriptionText,
+        },
+  ])
 
   return (
     <Tabs groups={map(items, (item) => ({
       title: item.title,
       component: (
         <div>
-          <div className='pv3 ph4 bg-black-10 f6'>
-            {item.description}
-          </div>
+          {item.description
+            ? <div className='pv3 ph4 bg-black-10 f6'>
+                {item.description}
+              </div>
+            : null
+          }
           <LessonList
             states={item.states}
             fallback={

--- a/src/utils/text/index.js
+++ b/src/utils/text/index.js
@@ -38,11 +38,9 @@ export const videoTitleText = 'Video'
 
 export const noVideoDescriptionText = 'No video'
 
-export const inProgressDescriptionText = 'These lessons are being worked on.'
 export const inReviewDescriptionText = 'These lessons are waiting for review to proceed.'
 export const selfReviewDescriptionText = 'Since you have 12+ lessons published, you can review your own lessons.'
 export const inQueueDescriptionText = 'These lessons are in the publishing queue. The queue automatically publishes them from top to bottom - unless they are a part of a course then they wait until the entire course is published.'
-export const publishedDescriptionText = 'These lessons are available publicly for students to view on egghead.io.'
 
 export const availableTitleText = 'Available'
 export const inProgressTitleText = 'In progress'


### PR DESCRIPTION
# Changes

- Remove "Published" tab from `LessonGroup` when for a specific instructor (currently `Dashboard` and `Instrutctor` screen `LessonGroups` instances). So now "Published" is only on the `Lessons` screen `LessonGroups` instance.
- Remove help description from `LessonGroup` "In Progress" and "Published" tabs, so help text now only shows on "In Review" and "In Queue".

# Result For User

![lesson-groups](https://cloud.githubusercontent.com/assets/5497885/24117495/1655e32c-0d70-11e7-8a30-a48a1ba79c12.gif)

---

![](https://media4.giphy.com/media/131bqhAGTB1mUM/giphy.gif)