### PR TITLE
Fix responsive layout issues (resolve #162, resolve #169)

### DIFF
--- a/src/components/LessonActions/index.js
+++ b/src/components/LessonActions/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import LessonStateProgression from './components/LessonStateProgression'
 import LessonEdit from './components/LessonEdit'
+import LessonStateProgression from './components/LessonStateProgression'
 
 export default ({lesson, requestLesson, requestCurrentPage}) => (
   <div>

--- a/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
@@ -7,7 +7,12 @@ import LessonActions from 'components/LessonActions'
 export default ({lesson, requestCurrentPage}) => {
   const {instructor} = lesson
   return (
-    <div className='flex items-start'>
+    <div
+      className='flex items-start'
+      style={{
+        wordBreak: 'break-word',
+      }}
+    >
 
       <img
         src={lesson.technology.logo_http_url}

--- a/src/screens/Instructors/components/InstructorListsByStatesCard/components/InstructorList/components/InstructorListItem/components/LessonGroupsStat/index.js
+++ b/src/screens/Instructors/components/InstructorListsByStatesCard/components/InstructorList/components/InstructorListItem/components/LessonGroupsStat/index.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import {Heading} from 'egghead-ui'
+
+export default ({label, count}) => (
+  <div className='pv2 ph3 bg-light-gray br2 tc'>
+    <Heading level='5'>
+      {label}
+    </Heading>
+    <div className='gray f4'>
+      {count}
+    </div>
+  </div>
+)

--- a/src/screens/Instructors/components/InstructorListsByStatesCard/components/InstructorList/components/InstructorListItem/index.js
+++ b/src/screens/Instructors/components/InstructorListsByStatesCard/components/InstructorList/components/InstructorListItem/index.js
@@ -1,24 +1,26 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
 import {Heading} from 'egghead-ui'
+import {
+  inProgressTitleText,
+  inReviewTitleText,
+  inQueueTitleText,
+  publishedTitleText,
+} from 'utils/text'
 import Avatar from 'components/Avatar'
-
-const LessonCount = ({label, count}) => (
-  <dl className="fl fn-l dib-l w-auto-l lh-title mr3-l">
-    <dd className="f6 fw4 ml0">{label}</dd>
-    <dd className="f3 fw6 ml0">{count}</dd>
-  </dl>
-)
+import LessonGroupsStat from './components/LessonGroupsStat'
 
 export default ({instructor}) => (
-  <div className='flex items-center'>
-    <div className='mr3'>
-      <Avatar
-        name={instructor.first_name}
-        url={instructor.avatar_url}
-      />
-    </div>
-    <div>
+  <div>
+
+    <div className='flex items-center'>
+
+      <div className='mr3'>
+        <Avatar
+          name={instructor.first_name}
+          url={instructor.avatar_url}
+        />
+      </div>
 
       <Link to={`/instructors/${instructor.slug}`}>
         <Heading level='3'>
@@ -26,40 +28,46 @@ export default ({instructor}) => (
         </Heading>
       </Link>
 
-      <section className="flex pa1">
-        <div className="cf">
-          {instructor.claimed_lessons 
-            ? <LessonCount
-                label='Claimed'
-                count={instructor.claimed_lessons}
-              /> 
-            : null
-          }
-          {instructor.submitted_lessons
-            ? <LessonCount
-                label='Submitted'
-                count={instructor.submitted_lessons}
-              /> 
-            : null
-          }
-          {instructor.approved_lessons
-            ? <LessonCount
-                label='Approved'
-                count={instructor.approved_lessons}
-              /> 
-            : null
-          }
-          {instructor.published_lessons
-            ? <LessonCount
-                label='Published'
-                count={instructor.published_lessons}
-              /> 
-            : null
-          }
-        </div>
-
-      </section>
     </div>
+
+    <section className="flex flex-wrap">
+      {instructor.claimed_lessons 
+        ? <div className='mt3 mr3'>
+            <LessonGroupsStat
+              label={inProgressTitleText}
+              count={instructor.claimed_lessons}
+            /> 
+          </div>
+        : null
+      }
+      {instructor.submitted_lessons
+        ? <div className='mt3 mr3'>
+            <LessonGroupsStat
+              label={inReviewTitleText}
+              count={instructor.submitted_lessons}
+            /> 
+          </div>
+        : null
+      }
+      {instructor.approved_lessons
+        ? <div className='mt3 mr3'>
+            <LessonGroupsStat
+              label={inQueueTitleText}
+              count={instructor.approved_lessons}
+            /> 
+          </div>
+        : null
+      }
+      {instructor.published_lessons
+        ? <div className='mt3'>
+            <LessonGroupsStat
+              label={publishedTitleText}
+              count={instructor.published_lessons}
+            /> 
+          </div>
+        : null
+      }
+    </section>
 
   </div>
 )

--- a/src/utils/text/index.js
+++ b/src/utils/text/index.js
@@ -43,9 +43,9 @@ export const selfReviewDescriptionText = 'Since you have 12+ lessons published, 
 export const inQueueDescriptionText = 'These lessons are in the publishing queue. The queue automatically publishes them from top to bottom - unless they are a part of a course then they wait until the entire course is published.'
 
 export const availableTitleText = 'Available'
-export const inProgressTitleText = 'In progress'
-export const inReviewTitleText = 'In review'
-export const inQueueTitleText = 'In queue'
+export const inProgressTitleText = 'In Progress'
+export const inReviewTitleText = 'In Review'
+export const inQueueTitleText = 'In Queue'
 export const publishedTitleText = 'Published'
 export const unusedTitleText = 'Unused'
 


### PR DESCRIPTION
# Changes

- Fix instructor list item stat responsive layout issues and make them look a little better
- Fix lesson long string overflow responsive layout issues

# Result For User

![instructor-list-item-stats](https://cloud.githubusercontent.com/assets/5497885/24120854/b4e3d214-0d7b-11e7-834d-1ddaf84f4708.gif)

![break-word](https://cloud.githubusercontent.com/assets/5497885/24120857/b904eea0-0d7b-11e7-97b7-73ae824d6cc5.gif)

---

![](https://media.giphy.com/media/xUA7bgQn7INAjDzQA0/giphy.gif)