### PR TITLE
Use Card from egghead-ui (resolve #187)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-scripts": "^0.8.4"
   },
   "dependencies": {
-    "egghead-ui": "^3.2.0",
+    "egghead-ui": "^3.3.1",
     "format-number": "^2.0.1",
     "honeybadger-js": "^0.4.3",
     "jwt-simple": "^0.5.1",

--- a/src/components/InstructorLessonsCard/index.js
+++ b/src/components/InstructorLessonsCard/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import LessonGroups from 'components/LessonGroups'
 
 export default ({instructor}) => (
-  <Card title={`${instructor.first_name}'s lessons`}>
+  <TitleCard title={`${instructor.first_name}'s lessons`}>
     <LessonGroups instructor={instructor} />
-  </Card>
+  </TitleCard>
 )

--- a/src/components/InstructorStatsCard/index.js
+++ b/src/components/InstructorStatsCard/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {map} from 'lodash'
 import {statsTitleText} from 'utils/text'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import List from 'components/List'
 import IconLabel from 'components/IconLabel'
 
@@ -23,13 +23,13 @@ export default ({publishedLessons, publishedCourses}) => {
   ]
 
   return (
-    <Card title={statsTitleText}>
+    <TitleCard title={statsTitleText}>
       <List items={map(items, (item, index) => (
         <IconLabel
           iconType={item.type}
           labelText={item.text}
         />
       ))} />
-    </Card>
+    </TitleCard>
   )
 }

--- a/src/components/ProposeCard/index.js
+++ b/src/components/ProposeCard/index.js
@@ -9,7 +9,7 @@ import {
   lessonTechnologyLabelText,
   lessonSummaryLabelText,
 } from 'utils/text'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import WrappedRequest from 'components/WrappedRequest'
 
 const inputClassNames = 'input-reset pa2 br2 ba b--light-gray w-100'
@@ -63,7 +63,7 @@ export default class Propose extends Component {
     const {instructor} = this.props
 
     return (
-      <Card
+      <TitleCard
         title={proposeActionText}
         description={newLessonSubmissionDescriptionText}
       >
@@ -161,7 +161,7 @@ export default class Propose extends Component {
           </WrappedRequest>
 
         </div>
-      </Card>
+      </TitleCard>
     )
   }
 }

--- a/src/components/RequestedCard/index.js
+++ b/src/components/RequestedCard/index.js
@@ -5,11 +5,11 @@ import {
   requestedDescriptionText,
   requestedEmptyDescriptionText,
 } from 'utils/text'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import LessonList from 'components/LessonList'
 
 export default () => (
-  <Card 
+  <TitleCard 
     title={requestedTitleText}
     description={requestedDescriptionText}
   >
@@ -23,5 +23,5 @@ export default () => (
         </div>
       }
     />
-  </Card>
+  </TitleCard>
 )

--- a/src/components/TitleCard/index.js
+++ b/src/components/TitleCard/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Heading, Paragraph} from 'egghead-ui'
+import {Heading, Paragraph, Card} from 'egghead-ui'
 
 export default ({children, title, description}) => (
   <section className='mb4'>
@@ -15,8 +15,8 @@ export default ({children, title, description}) => (
         </Paragraph>
       : null
     }
-    <div className='bg-white shadow-1 br2'>
+    <Card>
       {children}
-    </div>
+    </Card>
   </section>
 )

--- a/src/screens/Dashboard/components/GetPublishedCard/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/index.js
@@ -7,7 +7,7 @@ import {
 import {chatInfoUrl, roughDraftInfoUrl, gearSetupInfoUrl} from 'utils/urls'
 import {hasUnlockedPublished} from 'utils/milestones'
 import createLessonsUrl from 'utils/createLessonsUrl'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import WrappedRequest from 'components/WrappedRequest'
 import isStepComplete from './utils/isStepComplete'
 import Checklist from './components/Checklist'
@@ -23,7 +23,7 @@ export default ({instructor}) => hasUnlockedPublished(instructor.published_lesso
       {({data}) => {
         const instructorLessonStates = compact(uniq(map(data, 'state')))
         return (
-          <Card
+          <TitleCard
             title={getPublishedTitleText}
             description={getPublishedDescriptionText}
           >
@@ -67,7 +67,7 @@ export default ({instructor}) => hasUnlockedPublished(instructor.published_lesso
                 description: 'Publish lesson',
               },
             ]} />
-          </Card>
+          </TitleCard>
         )
       }}
     </WrappedRequest>

--- a/src/screens/Dashboard/components/HelpCard/index.js
+++ b/src/screens/Dashboard/components/HelpCard/index.js
@@ -12,7 +12,7 @@ import {
   instructorsChatActionText,
 } from 'utils/text'
 import {guideUrl, chatUrl, instructorsChatUrl} from 'utils/urls'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import List from 'components/List'
 import Anchor from 'components/Anchor'
 
@@ -35,7 +35,7 @@ const items=[
 ]
 
 export default ({publishedLessons}) => publishedLessons === 0
-  ? <Card
+  ? <TitleCard
       title={helpTitleText}
       description={helpDescriptionText}
     >
@@ -51,5 +51,5 @@ export default ({publishedLessons}) => publishedLessons === 0
           </Anchor>
         </div>
       ))} />
-    </Card>
+    </TitleCard>
   : null

--- a/src/screens/Dashboard/components/InstructionsCard/index.js
+++ b/src/screens/Dashboard/components/InstructionsCard/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {instructionsTitleText} from 'utils/text'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import Prompt from 'components/Prompt'
 
 export default ({
@@ -10,7 +10,7 @@ export default ({
   actionText,
   action,
 }) => condition
-  ? <Card title={instructionsTitleText}>
+  ? <TitleCard title={instructionsTitleText}>
       <div className='pa4'>
         Hey {instructor.first_name},
         <Prompt
@@ -19,5 +19,5 @@ export default ({
           action={action}
         />
       </div>
-    </Card>
+    </TitleCard>
   : null

--- a/src/screens/Dashboard/components/InstructorRevenueCard/index.js
+++ b/src/screens/Dashboard/components/InstructorRevenueCard/index.js
@@ -5,7 +5,7 @@ import {
   revenueTitleText,
 } from 'utils/text'
 import WrappedRequest from 'components/WrappedRequest'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import List from 'components/List'
 import currentMonthStartDate from './utils/currentMonthStartDate'
 import totalRevenue from './utils/totalRevenue'
@@ -41,7 +41,7 @@ export default ({revenueUrl}) => revenueUrl
         ]
 
         return (
-          <Card title={revenueTitleText}>
+          <TitleCard title={revenueTitleText}>
             <List items={map(items, (item, index) => (
               <RevenuePeriod
                 key={index}
@@ -50,7 +50,7 @@ export default ({revenueUrl}) => revenueUrl
                 subscriberMinutes={item.subscriberMinutes}
               />
             ))} />
-          </Card>
+          </TitleCard>
         )
       }}
     </WrappedRequest>

--- a/src/screens/Instructors/components/InstructorListsByStatesCard/index.js
+++ b/src/screens/Instructors/components/InstructorListsByStatesCard/index.js
@@ -3,14 +3,14 @@ import {filter, reject} from 'lodash'
 import {instructorsTitleText, unpublishedTitleText, publishedTitleText} from 'utils/text'
 import sortBy from 'sort-by'
 import WrappedRequest from 'components/WrappedRequest'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import Tabs from 'components/Tabs'
 import InstructorList from './components/InstructorList'
 
 export default ({instructors}) => (
   <WrappedRequest url='/api/v1/instructors'>
     {({data}) => (
-      <Card title={instructorsTitleText}>
+      <TitleCard title={instructorsTitleText}>
         <Tabs groups={[
           {
             title: unpublishedTitleText,
@@ -31,7 +31,7 @@ export default ({instructors}) => (
             ),
           },
         ]} />
-      </Card>
+      </TitleCard>
     )}
   </WrappedRequest>
 )

--- a/src/screens/Instructors/screens/Instructor/components/InstructorInfoCard/index.js
+++ b/src/screens/Instructors/screens/Instructor/components/InstructorInfoCard/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {map, compact} from 'lodash'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import List from 'components/List'
 import Avatar from 'components/Avatar'
 import InfoBit from './components/InfoBit'
@@ -45,8 +45,8 @@ export default ({instructor}) => {
   ])
 
   return (
-    <Card title={instructor.full_name}>
+    <TitleCard title={instructor.full_name}>
       <List items={map(items, (item, index) => item)} />
-    </Card>
+    </TitleCard>
   )
 }

--- a/src/screens/Lessons/components/LessonsCard/index.js
+++ b/src/screens/Lessons/components/LessonsCard/index.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import {lessonsTitleText} from 'utils/text'
-import Card from 'components/Card'
+import TitleCard from 'components/TitleCard'
 import LessonGroups from 'components/LessonGroups'
 
 export default () => (
-  <Card title={lessonsTitleText}>
+  <TitleCard title={lessonsTitleText}>
     <LessonGroups />
-  </Card>
+  </TitleCard>
 )

--- a/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
+++ b/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {map, compact} from 'lodash'
-import {Markdown, Heading} from 'egghead-ui'
+import {Card, Markdown, Heading} from 'egghead-ui'
 import {
   lessonStateTitleText,
   lessonActionsTitleText,
@@ -8,7 +8,6 @@ import {
   technologyTitleText,
   summaryTitleText,
 } from 'utils/text'
-import Card from 'components/Card'
 import List from 'components/List'
 import LessonState from 'components/LessonState'
 import LessonActions from 'components/LessonActions'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,9 +2115,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-egghead-ui@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/egghead-ui/-/egghead-ui-3.2.0.tgz#a68b7a0eb320c63042ee8d8313eec75a69aa5f94"
+egghead-ui@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/egghead-ui/-/egghead-ui-3.3.1.tgz#2bc67f2c8710048c37c2f3b475903105c74eddab"
   dependencies:
     "@kadira/storybook" "^2.5.2"
     axios "^0.15.3"


### PR DESCRIPTION
# Changes

- Use `Card` from `egghead-ui`
- Add `TitleCard` `Card` wrapper to deal with instructor center title/descriptions on cards

# Result For User

No change

---

![](https://media1.giphy.com/media/3o7TKuFYevgE2b6Mx2/giphy.gif)