### PR TITLE
Improve avatar use (resolve #192, resolve #165)

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
 
 const sizes = {
   1: 'w1 h1',
@@ -7,31 +7,13 @@ const sizes = {
   4: 'w4 h4',
 }
 
-const Avatar = ({name, url, size = 3}) => (
-  <div className={`dib v-top br-100 overflow-hidden ${sizes[size]}`}>
-    <div className='br-100 h-100 overflow-hidden relative'>
-      <img
-        alt={name}
-        src={url}
-        className='db'
-        style={{
-          minWidth: '100%',
-          minHeight: '100%',
-          margin: 'auto',
-          position: 'absolute',
-          top: '-100%',
-          right: '-100%',
-          bottom: '-100%',
-          left: '-100%',
-        }}
-      />
-    </div>
-  </div>
+export default ({name, url, size = 3}) => (
+  <div
+    className={`bg-gray dib br-100 ${sizes[size]}`}
+    style={{
+      background: `url(${url}) center center / cover no-repeat`,
+    }}
+    role='img'
+    aria-label={`Avatar for ${name}`}
+  />
 )
-
-Avatar.propTypes = {
-  name: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
-}
-
-export default Avatar

--- a/src/components/LessonActions/components/LessonEdit/index.js
+++ b/src/components/LessonActions/components/LessonEdit/index.js
@@ -13,7 +13,7 @@ export default ({lesson}) => (
       lesson.edit_lesson_http_url
         ? <div className='pa1'>
             <Anchor url={lesson.edit_lesson_http_url}>
-              <Button color='blue' size='extra-small'>
+              <Button size='extra-small'>
                 {editLessonTitleText}
               </Button>
             </Anchor>
@@ -24,7 +24,7 @@ export default ({lesson}) => (
       lesson.upload_lesson_http_url 
         ? <div className='pa1'>
             <Anchor url={lesson.upload_lesson_http_url}>
-              <Button color='blue' size='extra-small'>
+              <Button size='extra-small'>
                 {`${lesson.wistia_id ? replaceVideoTitleText : uploadVideoTitleText} Video`}
               </Button>
             </Anchor>

--- a/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
 import {Heading, Markdown} from 'egghead-ui'
+import Avatar from 'components/Avatar'
 import LessonState from 'components/LessonState'
 import LessonActions from 'components/LessonActions'
 
@@ -30,12 +31,20 @@ export default ({lesson, requestCurrentPage}) => {
 
         {lesson.state === 'requested' 
           ? null
-          : <Link to={`/instructors/${instructor.slug}`} className="no-underline">
-              <div className='flex items-center pt1'>
-                <img src={instructor.avatar_url} alt={instructor.full_name} className='w2 h2 br-pill mr2'/>
-                <span className='f6 ttc'>{instructor.full_name}</span>
-              </div>
-            </Link>
+          : <div className='mt3'>
+              <Link to={`/instructors/${instructor.slug}`}>
+                <div className='flex items-center'>
+                  <Avatar
+                    name={instructor.full_name}
+                    url={instructor.avatar_url}
+                    size={2}
+                  />
+                  <div className='ml3'>
+                    {instructor.full_name}
+                  </div>
+                </div>
+              </Link>
+            </div>
         }
 
         <div

--- a/src/components/LessonList/components/PaginatedLessonList/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/index.js
@@ -21,7 +21,7 @@ const PaginatedLessonList = ({
 
   const linkClassNames = {
     mobileHide: 'dn db-ns',
-    link: 'db dim bg-blue white mr2 pa2 ph3-ns br2',
+    link: 'db dim bg-orange white mr2 pa2 ph3-ns br2',
   }
 
   return total > 0

--- a/src/components/LoggedOut/index.js
+++ b/src/components/LoggedOut/index.js
@@ -20,7 +20,7 @@ export default () => (
 
     <div className='mb5'>
       <Anchor url={getLoginUrl()}>
-        <Button color='blue'>
+        <Button>
           {loginTitleText}
         </Button>
       </Anchor>

--- a/src/components/Prompt/index.js
+++ b/src/components/Prompt/index.js
@@ -15,12 +15,12 @@ export default ({
     <div className='mt3'>
       {startsWith(action, '/') 
         ? <Link to={action}>
-            <Button color='blue' size="extra-small">
+            <Button size="extra-small">
               {actionText}
             </Button>
           </Link>
         : <a href={action}>
-            <Button color='blue' size="extra-small">
+            <Button size="extra-small">
               {actionText}
             </Button>
           </a>

--- a/src/components/ProposeCard/index.js
+++ b/src/components/ProposeCard/index.js
@@ -144,7 +144,6 @@ export default class Propose extends Component {
           >
             {({request}) => (
               <Button
-                color='blue'
                 size='extra-small'
                 onClick={() => {
                   if(every([title, technologyId], (input) => size(input) > 0)) {

--- a/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
+++ b/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
@@ -43,14 +43,14 @@ export default ({lesson, requestLesson}) => {
           title: instructorTitleText,
           children: (
             <div className='flex items-center'>
-              <div className='mr2'>
-                <Avatar
-                  name={lesson.instructor.first_name}
-                  url={lesson.instructor.avatar_url}
-                  size={2}
-                />
+              <Avatar
+                name={lesson.instructor.first_name}
+                url={lesson.instructor.avatar_url}
+                size={3}
+              />
+              <div className='ml3'>
+                {lesson.instructor.full_name}
               </div>
-              {lesson.instructor.full_name}
             </div>
           ),
       },
@@ -61,7 +61,7 @@ export default ({lesson, requestLesson}) => {
           <img
             src={lesson.technology.logo_http_url}
             alt={lesson.technology.label}
-            className='mw2 mr2'
+            className='mw3 mr3'
           />
           {lesson.technology.label}
         </div>
@@ -81,7 +81,7 @@ export default ({lesson, requestLesson}) => {
     <Card>
       <List items={map(items, (item, index) => (
         <div>
-          <Heading level='5'>
+          <Heading level='3'>
             {item.title}
           </Heading>
           <div>


### PR DESCRIPTION
# Changes

- Use more robust avatar component setup that works for any image orientation (square, portrait, or landscape) and is accessible
- Use Avatar component in place of manual `<img>`
- Small style tweaks of things I think will look a bit better
- Use default button color in most places

# Result For User

<img width="279" alt="screen shot 2017-03-23 at 7 57 50 pm" src="https://cloud.githubusercontent.com/assets/5497885/24277550/5c51813e-1003-11e7-9131-d7c1f1a57eda.png">
<img width="286" alt="screen shot 2017-03-23 at 7 57 43 pm" src="https://cloud.githubusercontent.com/assets/5497885/24277549/5c516fb4-1003-11e7-8e08-9d7a9bf9de47.png">
<img width="172" alt="screen shot 2017-03-23 at 7 57 34 pm" src="https://cloud.githubusercontent.com/assets/5497885/24277554/633a062e-1003-11e7-9a01-84f66a45cfea.png">
<img width="164" alt="screen shot 2017-03-23 at 7 57 28 pm" src="https://cloud.githubusercontent.com/assets/5497885/24277555/633a458a-1003-11e7-8e75-3ee86d4372e4.png">

---

![](https://media.giphy.com/media/Z4YKVHaOo7k6Q/giphy.gif)