### PR TITLE
Add fallback shade for loading images (resolve #205)

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 
 const sizes = {
   1: 'w1 h1',
@@ -7,13 +7,50 @@ const sizes = {
   4: 'w4 h4',
 }
 
-export default ({name, url, size = 3}) => (
-  <div
-    className={`bg-gray dib br-100 ${sizes[size]}`}
-    style={{
-      background: `url(${url}) center center / cover no-repeat`,
-    }}
-    role='img'
-    aria-label={`Avatar for ${name}`}
-  />
-)
+export default class extends Component {
+
+  static defaultProps = {
+    size: 3,
+  }
+
+  state = {
+    hasLoaded: false,
+  }
+
+  handleLoad = () => {
+    this.setState({hasLoaded: true});
+  }
+
+  render() {
+    const {hasLoaded} = this.state
+    const {name, url, size} = this.props
+    const alt = `Avatar for ${name}`
+    const containerClassName = `bg-gray-secondary dib br-100 ${sizes[size]}`
+
+    if(hasLoaded) {
+      return (
+        <div
+          className={containerClassName}
+          style={{
+            background: `url(${url}) center center / cover no-repeat`,
+          }}
+          role='img'
+          aria-label={`Avatar for ${name}`}
+        />
+      )
+    }
+
+    return (
+      <div className={containerClassName}>
+        <img
+          onLoad={this.handleLoad}
+          src={url}
+          alt={alt}
+          style={{
+            display: 'none',
+          }}
+        />
+      </div>
+    )
+  }
+}

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -35,7 +35,7 @@ export default class extends Component {
             background: `url(${url}) center center / cover no-repeat`,
           }}
           role='img'
-          aria-label={`Avatar for ${name}`}
+          aria-label={alt}
         />
       )
     }

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -1,0 +1,40 @@
+import React, {Component} from 'react'
+
+export default class extends Component {
+
+  state = {
+    hasLoaded: false,
+  }
+
+  handleLoad = () => {
+    this.setState({hasLoaded: true});
+  }
+
+  render() {
+    const {hasLoaded} = this.state
+    const {src, alt, className} = this.props
+
+    if(hasLoaded) {
+      return (
+        <img
+          src={src}
+          alt={alt}
+          className={className}
+        />
+      )
+    }
+
+    return (
+      <div className={`bg-gray-secondary ${className}`}>
+        <img
+          onLoad={this.handleLoad}
+          src={src}
+          alt={alt}
+          style={{
+            display: 'none',
+          }}
+        />
+      </div>
+    )
+  }
+}

--- a/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
 import {Heading, Markdown} from 'egghead-ui'
+import Image from 'components/Image'
 import Avatar from 'components/Avatar'
 import LessonState from 'components/LessonState'
 import LessonActions from 'components/LessonActions'
@@ -15,10 +16,10 @@ export default ({lesson, requestCurrentPage}) => {
       }}
     >
 
-      <img
+      <Image 
         src={lesson.technology.logo_http_url}
         alt={lesson.technology.label}
-        className='mw2 mr3'
+        className='w2 h2 mr3'
       />
 
       <div>

--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -1,10 +1,11 @@
 import React from 'react'
+import Image from 'components/Image'
 import eggoIcon from './eggoIcon.svg'
 import eggoInstructorBanner from './eggoInstructorBanner.svg'
 import instructorBanner from './instructorBanner.svg'
 
 export const EggoIcon = ({className}) => (
-  <img
+  <Image 
     src={eggoIcon}
     alt='egghead.io instructors logo, eggo only'
     className={className}
@@ -12,7 +13,7 @@ export const EggoIcon = ({className}) => (
 )
 
 export const EggoInstructorBanner = ({className}) => (
-  <img
+  <Image
     src={eggoInstructorBanner}
     alt='egghead.io instructors logo'
     className={className}
@@ -20,7 +21,7 @@ export const EggoInstructorBanner = ({className}) => (
 )
 
 export const InstructorBanner = ({className}) => (
-  <img
+  <Image
     src={instructorBanner}
     alt='egghead.io instructors logo'
     className={className}

--- a/src/components/RouteNotFound/index.js
+++ b/src/components/RouteNotFound/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import {Heading, Paragraph} from 'egghead-ui'
 import {Text} from 'react-localize'
 import Main from 'components/Main'
+import Image from 'components/Image'
 import crackedEggo from './crackedEggo.png'
 
 export default () => (
@@ -9,7 +10,7 @@ export default () => (
     <Heading level='1'>
       <Text message='routeNotFound.title' />
     </Heading>
-    <img
+    <Image
       src={crackedEggo}
       alt='Cracked eggo logo'
     />

--- a/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
+++ b/src/screens/Lessons/screens/Lesson/components/LessonCard/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import {map, compact} from 'lodash'
 import {Markdown, Heading, List} from 'egghead-ui'
 import {Text} from 'react-localize'
+import Image from 'components/Image'
 import TitleCard from 'components/TitleCard'
 import LessonState from 'components/LessonState'
 import LessonActions from 'components/LessonActions'
@@ -52,7 +53,7 @@ export default ({lesson, requestLesson}) => {
       title: <Text message='lesson.technology' />,
       children: (
         <div className='flex items-center'>
-          <img
+          <Image
             src={lesson.technology.logo_http_url}
             alt={lesson.technology.label}
             className='mw3 mr3'


### PR DESCRIPTION
# Changes

- Adds fallback color for loading and errored images, without hurting accessibility

This was bugging me so I thought I'd knock it out real quick while in the middle of another PR; will now get back to the other PR. Both `Image` and `Avatar` could be potential uses to promote to `egghead-ui` or even just my npm.

# Result For User

Captured these screenshots with network throttling on as well as one image with a forced broken link:

<img width="812" alt="screen shot 2017-03-29 at 3 23 29 pm" src="https://cloud.githubusercontent.com/assets/5497885/24477349/e754f826-1493-11e7-9536-4d1515877f31.png">

<img width="498" alt="screen shot 2017-03-29 at 3 32 47 pm" src="https://cloud.githubusercontent.com/assets/5497885/24477642/ff303892-1494-11e7-8b17-de2990f41bc9.png">


---

![](https://media.giphy.com/media/3o7ZeT4XKYLG6x8zqo/giphy.gif)