### PR TITLE
General polish (resolve #212, resolve #177, resolve #157, resolve #211)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "7"
+- node
 cache: yarn
 script: yarn verify
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- node
+- "7"
 cache: yarn
 script: yarn verify
 deploy:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "chart.js": "^2.5.0",
-    "egghead-ui": "^4.4.0",
+    "egghead-ui": "^4.6.1",
     "format-number": "^2.0.1",
     "hex-rgba": "^1.0.1",
     "honeybadger-js": "^0.4.3",

--- a/src/components/InstructorLessonsCard/index.js
+++ b/src/components/InstructorLessonsCard/index.js
@@ -1,13 +1,16 @@
 import React from 'react'
 import {Text} from 'react-localize'
+import {Maybe} from 'egghead-ui'
 import TitleCard from 'components/TitleCard'
 import LessonGroups from 'components/LessonGroups'
 
 export default ({instructor}) => (
-  <TitleCard title={<Text
-    message='lessonGroups.instructorTitle'
-    values={[instructor.first_name]}
-  />}>
-    <LessonGroups instructor={instructor} />
-  </TitleCard>
+  <Maybe condition={instructor}>
+    <TitleCard title={<Text
+      message='lessonGroups.instructorTitle'
+      values={[instructor.first_name]}
+    />}>
+      <LessonGroups instructor={instructor} />
+    </TitleCard>
+  </Maybe>
 )

--- a/src/components/InstructorRevenueCard/index.js
+++ b/src/components/InstructorRevenueCard/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {find, size, map} from 'lodash'
-import {Card, Button, Heading} from 'egghead-ui'
+import {Card, Button, Heading, Maybe} from 'egghead-ui'
 import {Text} from 'react-localize'
 import WrappedRequest from 'components/WrappedRequest'
 import OpenToggle from 'components/OpenToggle'
@@ -10,8 +10,9 @@ import removeRevenueMonth from './utils/removeRevenueMonth'
 import RevenuePeriod from './components/RevenuePeriod'
 import LineChart from './components/LineChart'
 
-export default ({revenueUrl}) => revenueUrl
-  ? <WrappedRequest url={revenueUrl}>
+export default ({revenueUrl}) => (
+  <Maybe condition={Boolean(revenueUrl)}>
+    <WrappedRequest url={revenueUrl}>
       {({data}) => {
         const currentMonthRevenue = find(data, ['month', currentMonthStartDate()])
         const currentTotalRevenue = totalRevenue(removeRevenueMonth(data, currentMonthStartDate()))
@@ -34,9 +35,8 @@ export default ({revenueUrl}) => revenueUrl
               <Card>
                 <div className='flex-l justify-between-l'>
 
-                  {isOpen
-                    ? null
-                    : <div className='pa5 nowrap-l'>
+                  <Maybe condition={!isOpen}>
+                    <div className='pa5 nowrap-l'>
 
                         <div className='mb4'>
                           <RevenuePeriod
@@ -65,7 +65,7 @@ export default ({revenueUrl}) => revenueUrl
                         </div>
 
                       </div>
-                  }
+                  </Maybe>
 
                   {isOpen
                     ? <div className='pa4 w-100'>
@@ -120,4 +120,5 @@ export default ({revenueUrl}) => revenueUrl
         )
       }}
     </WrappedRequest>
-  : null
+  </Maybe>
+)

--- a/src/components/InstructorStatsCard/components/InstructorStat/index.js
+++ b/src/components/InstructorStatsCard/components/InstructorStat/index.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import {map} from 'lodash'
+import Anchor from 'components/Anchor'
+import Image from 'components/Image'
+
+export default ({count, label, graphics}) => (
+  <div className='flex justify-center'>
+    <div className='flex items-center'>
+      <div className='base f3 b mr2'>
+        {count}
+      </div>
+      <div>
+        {label}
+      </div>
+    </div>
+    <div>
+      {map(graphics, graphic => (
+        <Anchor 
+          key={graphic.label}
+          url={graphic.http_url}
+        >
+          <Image 
+            src={graphic.logo_http_url}
+            alt={graphic.label}
+          />
+        </Anchor>
+      ))}
+    </div>
+  </div>
+)

--- a/src/components/InstructorStatsCard/components/InstructorStat/index.js
+++ b/src/components/InstructorStatsCard/components/InstructorStat/index.js
@@ -22,7 +22,7 @@ export default ({count, label, graphics}) => (
           <Image 
             src={graphic.logo_http_url}
             alt={graphic.label}
-            className='w2 mr3 mb3'
+            className='w2 mr3 mb3 grow-large'
           />
         </Anchor>
       ))}

--- a/src/components/InstructorStatsCard/components/InstructorStat/index.js
+++ b/src/components/InstructorStatsCard/components/InstructorStat/index.js
@@ -4,8 +4,8 @@ import Anchor from 'components/Anchor'
 import Image from 'components/Image'
 
 export default ({count, label, graphics}) => (
-  <div className='flex justify-center'>
-    <div className='flex items-center'>
+  <div>
+    <div className='flex items-center justify-center mb3'>
       <div className='base f3 b mr2'>
         {count}
       </div>
@@ -13,15 +13,16 @@ export default ({count, label, graphics}) => (
         {label}
       </div>
     </div>
-    <div>
+    <div className='flex flex-wrap justify-center'>
       {map(graphics, graphic => (
         <Anchor 
-          key={graphic.label}
+          key={graphic.name}
           url={graphic.http_url}
         >
           <Image 
             src={graphic.logo_http_url}
             alt={graphic.label}
+            className='w2 mr3 mb3'
           />
         </Anchor>
       ))}

--- a/src/components/InstructorStatsCard/index.js
+++ b/src/components/InstructorStatsCard/index.js
@@ -16,32 +16,32 @@ export default ({instructor}) => {
   return (
     <Card>
       <div className='pa5'>
-        <div className='mb5'>
-          <WrappedRequest
-            url={createLessonsUrl({
-              lessons_url: instructor.lessons_url
-            })}
-          >
-            {({data}) => (
+        <WrappedRequest
+          url={createLessonsUrl({
+            lessons_url: instructor.lessons_url
+          })}
+        >
+          {({data}) => (
+            <InstructorStat
+              count={instructor.published_lessons}
+              label={pluralize('Lesson', instructor.published_lessons)}
+              graphics={uniqBy(map(data, lesson => ({
+                ...lesson.technology,
+              })), technology => technology.name)}
+            />
+          )}
+        </WrappedRequest>
+        {/* 
+        <div className='mt5'>
+          <WrappedRequest url={`/api/v1/series?instructor_id=${instructor.id}`}>
+            {({data}) => console.log('data', data) || (
               <InstructorStat
-                count={instructor.published_lessons}
-                label={pluralize('Lesson', instructor.published_lessons)}
-                graphics={uniqBy(map(data, lesson => ({
-                  ...lesson.technology,
-                })), technology => technology.name)}
+                count={instructor.published_courses}
+                label={pluralize('Course', instructor.published_courses)}
               />
             )}
           </WrappedRequest>
         </div>
-        {/* 
-        <WrappedRequest url={`/api/v1/series?instructor_id=${instructor.id}`}>
-          {({data}) => console.log('data', data) || (
-            <InstructorStat
-              count={instructor.published_courses}
-              label={pluralize('Course', instructor.published_courses)}
-            />
-          )}
-        </WrappedRequest>
         */}
       </div>
     </Card>

--- a/src/components/InstructorStatsCard/index.js
+++ b/src/components/InstructorStatsCard/index.js
@@ -1,55 +1,49 @@
 import React from 'react'
-import {map} from 'lodash'
-import {List} from 'egghead-ui'
-import {Text} from 'react-localize'
 import pluralize from 'pluralize'
-import TitleCard from 'components/TitleCard'
-import IconLabel from 'components/IconLabel'
+import {map, uniqBy} from 'lodash'
+import {Card} from 'egghead-ui'
+import {hasUnlockedPublished} from 'utils/milestones'
+import createLessonsUrl from 'utils/createLessonsUrl'
+import WrappedRequest from 'components/WrappedRequest'
+import InstructorStat from './components/InstructorStat'
 
-export default ({publishedLessons, publishedCourses}) => {
+export default ({instructor}) => {
 
-  if(!publishedLessons) {
+  if(!hasUnlockedPublished(instructor.published_lessons)) {
     return null
   }
 
-  const items = [
-    {
-      type: 'lesson',
-      text: (
-        <span>
-          <Text 
-            message='instructorStats.lessons'
-            values={[publishedLessons]} 
-          />
-          <span>{` ${pluralize('lesson', publishedLessons)}`}</span>
-        </span>
-      ),
-      color: 'green',
-    },
-    {
-      type: 'course',
-      text: (
-        <span>
-          <Text 
-            message='instructorStats.courses'
-            values={[publishedCourses]} 
-          />
-          <span>{` ${pluralize('course', publishedCourses)}`}</span>
-        </span>
-      ),
-      color: 'orange',
-    },
-  ]
-
   return (
-    <TitleCard title={<Text message='instructorStats.title' />}>
-      <List items={map(items, (item, index) => (
-        <IconLabel
-          iconType={item.type}
-          labelText={item.text}
-          color={item.color}
-        />
-      ))} />
-    </TitleCard>
+    <Card>
+      <div className='pa5'>
+        <div className='mb5'>
+          <WrappedRequest
+            url={createLessonsUrl({
+              lessons_url: instructor.lessons_url
+            })}
+          >
+            {({data}) => (
+              <InstructorStat
+                count={instructor.published_lessons}
+                label={pluralize('Lesson', instructor.published_lessons)}
+                graphics={uniqBy(map(data, lesson => ({
+                  ...lesson.technology,
+                })), technology => technology.name)}
+              />
+            )}
+          </WrappedRequest>
+        </div>
+        {/* 
+        <WrappedRequest url={`/api/v1/series?instructor_id=${instructor.id}`}>
+          {({data}) => console.log('data', data) || (
+            <InstructorStat
+              count={instructor.published_courses}
+              label={pluralize('Course', instructor.published_courses)}
+            />
+          )}
+        </WrappedRequest>
+        */}
+      </div>
+    </Card>
   )
 }

--- a/src/components/LessonActions/components/LessonEdit/index.js
+++ b/src/components/LessonActions/components/LessonEdit/index.js
@@ -1,36 +1,38 @@
 import React from 'react'
-import {Maybe, Button} from 'egghead-ui'
+import {Button} from 'egghead-ui'
 import {Text} from 'react-localize'
 import Anchor from 'components/Anchor'
 
 export default ({lesson}) => (
   <div className='flex flex-wrap'>
-    <Maybe condition={Boolean(lesson.edit_lesson_http_url)}>
-      <div className='pr2 pb2'>
-        <Anchor url={lesson.edit_lesson_http_url}>
-          <Button 
-            color='base'
-            size='extra-small'
-          >
-            <Text message='lessonEdit.edit' />
-          </Button>
-        </Anchor>
-      </div>
-    </Maybe>
-    <Maybe condition={Boolean(lesson.upload_lesson_http_url)}>
-      <div className='pb2'>
-        <Anchor url={lesson.upload_lesson_http_url}>
-          <Button
-            color='base'
-            size='extra-small'
-          >
-            {lesson.wistia_id
-              ? <Text message='lessonEdit.replaceVideo' />
-              : <Text message='lessonEdit.uploadVideo' />
-            }
-          </Button>
-        </Anchor>
-      </div>
-    </Maybe>
+    {lesson.edit_lesson_http_url
+      ? <div className='pr2 pb2'>
+          <Anchor url={lesson.edit_lesson_http_url}>
+            <Button 
+              color='base'
+              size='extra-small'
+            >
+              <Text message='lessonEdit.edit' />
+            </Button>
+          </Anchor>
+        </div>
+      : null
+    }
+    {lesson.upload_lesson_http_url
+      ? <div className='pb2'>
+          <Anchor url={lesson.upload_lesson_http_url}>
+            <Button
+              color='base'
+              size='extra-small'
+            >
+              {lesson.wistia_id
+                ? <Text message='lessonEdit.replaceVideo' />
+                : <Text message='lessonEdit.uploadVideo' />
+              }
+            </Button>
+          </Anchor>
+        </div>
+      : null
+    }
   </div>
 )

--- a/src/components/LessonActions/components/LessonEdit/index.js
+++ b/src/components/LessonActions/components/LessonEdit/index.js
@@ -1,40 +1,36 @@
 import React from 'react'
-import {Button} from 'egghead-ui'
+import {Maybe, Button} from 'egghead-ui'
 import {Text} from 'react-localize'
 import Anchor from 'components/Anchor'
 
 export default ({lesson}) => (
   <div className='flex flex-wrap'>
-    {
-      lesson.edit_lesson_http_url
-        ? <div className='pr2 pb2'>
-            <Anchor url={lesson.edit_lesson_http_url}>
-              <Button 
-                color='base'
-                size='extra-small'
-              >
-                <Text message='lessonEdit.edit' />
-              </Button>
-            </Anchor>
-          </div>
-        : null
-    }
-    {
-      lesson.upload_lesson_http_url 
-        ? <div className='pb2'>
-            <Anchor url={lesson.upload_lesson_http_url}>
-              <Button
-                color='base'
-                size='extra-small'
-              >
-                {lesson.wistia_id
-                  ? <Text message='lessonEdit.replaceVideo' />
-                  : <Text message='lessonEdit.uploadVideo' />
-                }
-              </Button>
-            </Anchor>
-          </div>
-        : null
-    }
+    <Maybe condition={Boolean(lesson.edit_lesson_http_url)}>
+      <div className='pr2 pb2'>
+        <Anchor url={lesson.edit_lesson_http_url}>
+          <Button 
+            color='base'
+            size='extra-small'
+          >
+            <Text message='lessonEdit.edit' />
+          </Button>
+        </Anchor>
+      </div>
+    </Maybe>
+    <Maybe condition={Boolean(lesson.upload_lesson_http_url)}>
+      <div className='pb2'>
+        <Anchor url={lesson.upload_lesson_http_url}>
+          <Button
+            color='base'
+            size='extra-small'
+          >
+            {lesson.wistia_id
+              ? <Text message='lessonEdit.replaceVideo' />
+              : <Text message='lessonEdit.uploadVideo' />
+            }
+          </Button>
+        </Anchor>
+      </div>
+    </Maybe>
   </div>
 )

--- a/src/components/LessonActions/components/LessonStateProgression/index.js
+++ b/src/components/LessonActions/components/LessonStateProgression/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {map, keys} from 'lodash'
-import {Button} from 'egghead-ui'
+import {Maybe, Button} from 'egghead-ui'
 import {lessonStateVerbToPastTense, detailsByLessonState} from 'utils/lessonStates'
 import WrappedRequest from 'components/WrappedRequest'
 
@@ -10,9 +10,12 @@ export default ({lesson, onLessonStateChange}) => (
   <div className='flex flex-wrap'>
     {map(stateVerbs, (stateVerb, index) => {
       const stateVerbUrl = lesson[`${stateVerb}_url`]
-      return stateVerbUrl
-        ? <WrappedRequest
-            key={stateVerb}
+      return (
+        <Maybe 
+          key={stateVerb}
+          condition={Boolean(stateVerbUrl)}
+        >
+          <WrappedRequest
             lazy
             method='post'
             url={stateVerbUrl}
@@ -30,7 +33,8 @@ export default ({lesson, onLessonStateChange}) => (
               </div>
             )}
           </WrappedRequest>
-        : null
+        </Maybe>
+      )
     })}
   </div>
 )

--- a/src/components/LessonGroups/index.js
+++ b/src/components/LessonGroups/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {map, compact} from 'lodash'
 import {Text} from 'react-localize'
+import {Maybe} from 'egghead-ui'
 import {publicLessonsUrl} from 'utils/urls'
 import {hasUnlockedSelfReview} from 'utils/milestones'
 import LessonList from 'components/LessonList'
@@ -24,13 +25,12 @@ export default ({instructor}) => {
       description: (
         <span>
           <Text message='lessonGroups.inReview.description' />
-          {instructor && hasUnlockedSelfReview(instructor.published_lessons)
-            ? <span>
-                <span>{` `}</span>
-                <Text message='lessonGroups.inReview.selfApproval' />
-              </span>
-            : null
-          }
+          <Maybe condition={Boolean(instructor && hasUnlockedSelfReview(instructor.published_lessons))}>
+            <span>
+              <span>{` `}</span>
+              <Text message='lessonGroups.inReview.selfApproval' />
+            </span>
+          </Maybe>
         </span>
       ),
       states: [
@@ -56,12 +56,11 @@ export default ({instructor}) => {
         title: item.title,
         component: (
           <div>
-            {item.description
-              ? <div className='pv3 ph4 bg-gray f6'>
-                  {item.description}
-                </div>
-              : null
-            }
+            <Maybe condition={Boolean(item.description)}>
+              <div className='pv3 ph4 bg-gray f6'>
+                {item.description}
+              </div>
+            </Maybe>
             <LessonList
               states={item.states}
               fallback={

--- a/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/components/LessonListItem/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
-import {Heading, Markdown} from 'egghead-ui'
+import {Maybe, Heading, Markdown} from 'egghead-ui'
 import Image from 'components/Image'
 import Avatar from 'components/Avatar'
 import LessonState from 'components/LessonState'
@@ -30,23 +30,22 @@ export default ({lesson, requestCurrentPage}) => {
           </Heading>
         </Link>
 
-        {lesson.state === 'requested' 
-          ? null
-          : <div className='mt3'>
-              <Link to={`/instructors/${instructor.slug}`}>
-                <div className='flex items-center'>
-                  <Avatar
-                    name={instructor.full_name}
-                    url={instructor.avatar_url}
-                    size={2}
-                  />
-                  <div className='ml3'>
-                    {instructor.full_name}
-                  </div>
+        <Maybe condition={lesson.state !== 'requested'}>
+          <div className='mt3'>
+            <Link to={`/instructors/${instructor.slug}`}>
+              <div className='flex items-center'>
+                <Avatar
+                  name={instructor.full_name}
+                  url={instructor.avatar_url}
+                  size={2}
+                />
+                <div className='ml3'>
+                  {instructor.full_name}
                 </div>
-              </Link>
-            </div>
-        }
+              </div>
+            </Link>
+          </div>
+        </Maybe>
 
         <div
           className='mt2'
@@ -54,12 +53,11 @@ export default ({lesson, requestCurrentPage}) => {
             wordBreak: 'break-word',
           }}
         >
-          {lesson.summary
-            ? <Markdown>
-                {lesson.summary}
-              </Markdown>
-            : null
-          }
+          <Maybe condition={Boolean(lesson.summary)}>
+            <Markdown>
+              {lesson.summary}
+            </Markdown>
+          </Maybe>
         </div>
 
         <div className='mt3'>

--- a/src/components/LessonList/components/PaginatedLessonList/index.js
+++ b/src/components/LessonList/components/PaginatedLessonList/index.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react'
 import ReactPaginate from 'react-paginate'
 import {map} from 'lodash'
-import {List} from 'egghead-ui'
+import {Maybe, List} from 'egghead-ui'
 import {Text} from 'react-localize'
 import sortLessonsByState from './utils/sortLessonsByState'
 import LessonListItem from './components/LessonListItem'
@@ -35,34 +35,33 @@ const PaginatedLessonList = ({
           />
         ))} />
 
-        {hasMoreThanOnePage
-          ? <div className='pa3'>
-              <ReactPaginate
-                pageNum={pageNum}
-                pageRangeDisplayed={3}
-                marginPagesDisplayed={1}
-                initialSelected={currentPage - 1}
-                previousLabel={<Text message='pagination.previous' />}
-                nextLabel={<Text message='pagination.next' />}
-                clickCallback={(page) => {
-                  const {selected} = page
-                  if (currentPage !== selected + 1) {
-                    requestNextPage(selected + 1)
-                  }
-                }}
-                containerClassName='mb0 pa0 list mt4 flex items-center'
-                previousClassName={linkClassNames.mobileHide}
-                nextClassName={linkClassNames.mobileHide}
-                disabledClassName='o-20'
-                previousLinkClassName={linkClassNames.link}
-                nextLinkClassName={linkClassNames.link}
-                pageLinkClassName={linkClassNames.link}
-                activeClassName='o-50'
-                breakClassName='mr2'
-              />
-            </div>
-          : null
-        }
+        <Maybe condition={hasMoreThanOnePage}>
+          <div className='pa3'>
+            <ReactPaginate
+              pageNum={pageNum}
+              pageRangeDisplayed={3}
+              marginPagesDisplayed={1}
+              initialSelected={currentPage - 1}
+              previousLabel={<Text message='pagination.previous' />}
+              nextLabel={<Text message='pagination.next' />}
+              clickCallback={(page) => {
+                const {selected} = page
+                if (currentPage !== selected + 1) {
+                  requestNextPage(selected + 1)
+                }
+              }}
+              containerClassName='mb0 pa0 list mt4 flex items-center'
+              previousClassName={linkClassNames.mobileHide}
+              nextClassName={linkClassNames.mobileHide}
+              disabledClassName='o-20'
+              previousLinkClassName={linkClassNames.link}
+              nextLinkClassName={linkClassNames.link}
+              pageLinkClassName={linkClassNames.link}
+              activeClassName='o-50'
+              breakClassName='mr2'
+            />
+          </div>
+        </Maybe>
 
       </div>
     : fallback

--- a/src/components/RequestedLessonsCard/components/ProposeLesson/components/ProposeLessonForm/index.js
+++ b/src/components/RequestedLessonsCard/components/ProposeLesson/components/ProposeLessonForm/index.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react'
 import {map, size, every} from 'lodash'
-import {Error, Button, Paragraph} from 'egghead-ui'
+import {Maybe, Error, Button, Paragraph} from 'egghead-ui'
 import {Text} from 'react-localize'
 import WrappedRequest from 'components/WrappedRequest'
 
@@ -111,14 +111,13 @@ export default class extends Component {
           />
         </div>
 
-        {hasMissingInput
-          ? <div className='mb3'>
-              <Error>
-                <Text message='requestedLessons.proposeLesson.missingInputError' />
-              </Error>
-            </div>
-          : null
-        }
+        <Maybe condition={hasMissingInput}>
+          <div className='mb3'>
+            <Error>
+              <Text message='requestedLessons.proposeLesson.missingInputError' />
+            </Error>
+          </div>
+        </Maybe>
 
         <WrappedRequest
           lazy

--- a/src/components/TitleCard/index.js
+++ b/src/components/TitleCard/index.js
@@ -1,7 +1,12 @@
 import React from 'react'
 import {Maybe, Heading, Paragraph, Card} from 'egghead-ui'
 
-export default ({children, title, description = false}) => (
+export default ({
+  children, 
+  title, 
+  description = false, 
+  intro = false,
+}) => (
   <section className='br2 bg-white-secondary shadow-1'>
     <div className='pa4'>
       <Heading level='5'>
@@ -11,6 +16,9 @@ export default ({children, title, description = false}) => (
         <Paragraph type='small'>
           {description}
         </Paragraph>
+      </Maybe>
+      <Maybe condition={Boolean(intro)}>
+        {intro}
       </Maybe>
     </div>
     <Card>

--- a/src/components/TitleCard/index.js
+++ b/src/components/TitleCard/index.js
@@ -1,18 +1,17 @@
 import React from 'react'
-import {Heading, Paragraph, Card} from 'egghead-ui'
+import {Maybe, Heading, Paragraph, Card} from 'egghead-ui'
 
-export default ({children, title, description}) => (
+export default ({children, title, description = false}) => (
   <section className='br2 bg-white-secondary shadow-1'>
     <div className='pa4'>
       <Heading level='5'>
         {title}
       </Heading>
-      {description
-        ? <Paragraph type='small'>
-            {description}
-          </Paragraph>
-        : null
-      }
+      <Maybe condition={Boolean(description)}>
+        <Paragraph type='small'>
+          {description}
+        </Paragraph>
+      </Maybe>
     </div>
     <Card>
       {children}

--- a/src/index.js
+++ b/src/index.js
@@ -49,9 +49,8 @@ const App = () => {
             </Localization>
           )
         }
-
         if (process.env.NODE_ENV === 'production') {
-          initializeErrorTracking(user.id)
+          initializeErrorTracking(user)
         }
 
         return (

--- a/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/components/MoreInfo.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/components/MoreInfo.js
@@ -1,18 +1,14 @@
-import React, {PropTypes} from 'react'
-import {Icon} from 'egghead-ui'
+import React from 'react'
+import {Maybe, Icon} from 'egghead-ui'
 import Anchor from 'components/Anchor'
 
-const MoreInfo = ({url}) => (
-  <Anchor 
-    url={url}
-    isSeparateTab
-  >
-    <Icon type='info' />
-  </Anchor>
+export default ({url}) => (
+  <Maybe condition={Boolean(url)}>
+    <Anchor 
+      url={url}
+      isSeparateTab
+    >
+      <Icon type='info' />
+    </Anchor>
+  </Maybe>
 )
-
-MoreInfo.propTypes = {
-  url: PropTypes.string.isRequired,
-}
-
-export default MoreInfo

--- a/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/components/MoreInfo/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/components/MoreInfo/index.js
@@ -8,7 +8,10 @@ export default ({url}) => (
       url={url}
       isSeparateTab
     >
-      <Icon type='info' />
+      <Icon 
+        type='info' 
+        size='4'
+      />
     </Anchor>
   </Maybe>
 )

--- a/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/index.js
@@ -4,55 +4,54 @@ import {map} from 'lodash'
 import {Icon, List} from 'egghead-ui'
 import MoreInfo from './components/MoreInfo'
 
-const completedOpacity = 'o-30'
-
 export default ({items}) => (
   <List items={map(items, (item, index) => (
     <div 
       key={index}
-      className='flex items-center justify-between b'
+      className='flex items-center justify-between'
     >
 
       <div className='flex items-center'>
 
-        <div className='mr2'>
-          {item.isComplete
-            ? <div className={completedOpacity}>
-                <Icon type='box-check' />
-              </div>
-            : <Icon type='box' />
-          }
+        <div className='mr3'>
+          {index + 1}
         </div>
 
         <span className={item.isComplete
-          ? `strike ${completedOpacity}`
-          : ''
+          ? `strike gray-secondary`
+          : 'base'
         }>
           {item.description}
         </span>
 
       </div>
 
-      <div className={item.isComplete
-        ? completedOpacity
-        : ''
-      }>
-        {item.moreInfoUrl
-          ? <span className='ml2'>
-              <MoreInfo url={item.moreInfoUrl} />
-            </span>
-          : null
-        }
-        {item.action
-          ? <Link 
-              to={item.action}
-              className='ml2'
-            >
-              <Icon type='arrow-right' />
-            </Link>
-          : null
-        }
-      </div>
+      {item.isComplete
+        ? <Icon 
+            type='check' 
+            color='green'
+          />
+        : <div>
+            {item.moreInfoUrl
+              ? <span className='ml2'>
+                  <MoreInfo url={item.moreInfoUrl} />
+                </span>
+              : null
+            }
+            {item.action
+              ? <Link 
+                  to={item.action}
+                  className='ml2'
+                >
+                  <Icon 
+                    type='chevron-right' 
+                    size='4'
+                  />
+                </Link>
+              : null
+            }
+          </div>
+      }
 
     </div>
   ))} />

--- a/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/index.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react'
 import {Link} from 'react-router-dom'
 import {map} from 'lodash'
-import {Icon, List} from 'egghead-ui'
+import {Maybe, Icon, List} from 'egghead-ui'
 import MoreInfo from './components/MoreInfo'
 
 const completedOpacity = 'o-30'
@@ -37,21 +37,19 @@ const Checklist = ({items}) => (
         ? completedOpacity
         : ''
       }>
-        {item.moreInfoUrl
-          ? <span className='ml2'>
-              <MoreInfo url={item.moreInfoUrl} />
-            </span>
-          : null
-        }
-        {item.action
-          ? <Link 
-              to={item.action}
-              className='ml2'
-            >
-              <Icon type='arrow-right' />
-            </Link>
-          : null
-        }
+        <Maybe condition={Boolean(item.moreInfoUrl)}>
+          <span className='ml2'>
+            <MoreInfo url={item.moreInfoUrl} />
+          </span>
+        </Maybe>
+        <Maybe condition={Boolean(item.action)}>
+          <Link 
+            to={item.action}
+            className='ml2'
+          >
+            <Icon type='arrow-right' />
+          </Link>
+        </Maybe>
       </div>
 
     </div>

--- a/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
 import {map} from 'lodash'
-import {Maybe, Icon, List} from 'egghead-ui'
+import {Icon, List} from 'egghead-ui'
 import MoreInfo from './components/MoreInfo'
 
 const completedOpacity = 'o-30'
@@ -37,19 +37,21 @@ export default ({items}) => (
         ? completedOpacity
         : ''
       }>
-        <Maybe condition={Boolean(item.moreInfoUrl)}>
-          <span className='ml2'>
-            <MoreInfo url={item.moreInfoUrl} />
-          </span>
-        </Maybe>
-        <Maybe condition={Boolean(item.action)}>
-          <Link 
-            to={item.action}
-            className='ml2'
-          >
-            <Icon type='arrow-right' />
-          </Link>
-        </Maybe>
+        {item.moreInfoUrl
+          ? <span className='ml2'>
+              <MoreInfo url={item.moreInfoUrl} />
+            </span>
+          : null
+        }
+        {item.action
+          ? <Link 
+              to={item.action}
+              className='ml2'
+            >
+              <Icon type='arrow-right' />
+            </Link>
+          : null
+        }
       </div>
 
     </div>

--- a/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/components/Checklist/index.js
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
 import {Link} from 'react-router-dom'
 import {map} from 'lodash'
 import {Maybe, Icon, List} from 'egghead-ui'
@@ -6,7 +6,7 @@ import MoreInfo from './components/MoreInfo'
 
 const completedOpacity = 'o-30'
 
-const Checklist = ({items}) => (
+export default ({items}) => (
   <List items={map(items, (item, index) => (
     <div 
       key={index}
@@ -55,14 +55,3 @@ const Checklist = ({items}) => (
     </div>
   ))} />
 )
-
-Checklist.propTypes = {
-  items: PropTypes.arrayOf(PropTypes.shape({
-    isComplete: PropTypes.bool.isRequired,
-    description: PropTypes.string.isRequired,
-    actionUrl: PropTypes.string,
-    moreInfoUrl: PropTypes.string,
-  })).isRequired,
-}
-
-export default Checklist

--- a/src/screens/Dashboard/components/GetPublishedCard/components/Progress/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/components/Progress/index.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import {Text} from 'react-localize'
+
+const barHeight = 7
+
+export default ({total, complete}) => (
+  <div>
+
+    <div className='flex f6'>
+      <div className='green mr1'>
+        {complete}
+      </div>
+      <div className='mr1'>
+        /
+      </div>
+      <div className='mr1'>
+        {total} 
+      </div>
+      <div>
+        <Text message='progress.completed' />
+      </div>
+    </div>
+
+    <div className='mt2'>
+      <div 
+        className='br2 bg-gray-secondary'
+        style={{
+          height: barHeight,
+        }}
+      >
+        <div 
+          className='br2 bg-green'
+          style={{
+            height: barHeight,
+            width: `${complete / total * 100}%`,
+          }}
+        />
+      </div>
+    </div>
+  </div>
+)

--- a/src/screens/Dashboard/components/GetPublishedCard/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {map, uniq, compact, isString} from 'lodash'
+import {map, uniq, compact, isString, size, filter} from 'lodash'
 import {Text} from 'react-localize'
 import {Maybe} from 'egghead-ui'
 import {chatInfoUrl, roughDraftInfoUrl, gearSetupInfoUrl} from 'utils/urls'
@@ -8,6 +8,7 @@ import createLessonsUrl from 'utils/createLessonsUrl'
 import TitleCard from 'components/TitleCard'
 import WrappedRequest from 'components/WrappedRequest'
 import isStepComplete from './utils/isStepComplete'
+import Progress from './components/Progress'
 import Checklist from './components/Checklist'
 
 export default ({instructor}) => (
@@ -20,51 +21,60 @@ export default ({instructor}) => (
     >
       {({data}) => {
         const instructorLessonStates = compact(uniq(map(data, 'state')))
+
+        const checklistItems = [
+          {
+            isComplete: true,
+            description: 'Create instructor account',
+          },
+          {
+            isComplete: isString(instructor.slack_id),
+            description: 'Join egghead Slack',
+            moreInfoUrl: chatInfoUrl,
+          },
+          {
+            isComplete: isStepComplete(instructorLessonStates, 'claimed'),
+            description: 'Claim new lesson',
+            action: '/lessons/new',
+          },
+          {
+            isComplete: isStepComplete(instructorLessonStates, 'submitted'),
+            description: 'Submit rough draft',
+            moreInfoUrl: roughDraftInfoUrl,
+          },
+          {
+            isComplete: isString(instructor.gear_tracking_id),
+            description: 'Get gear',
+            moreInfoUrl: gearSetupInfoUrl,
+          },
+          {
+            isComplete: isStepComplete(instructorLessonStates, 'updated'),
+            description: 'Re-record with gear',
+            moreInfoUrl: roughDraftInfoUrl,
+          },
+          {
+            isComplete: isStepComplete(instructorLessonStates, 'approved'),
+            description: 'Iterate until approved',
+            moreInfoUrl: roughDraftInfoUrl,
+          },
+          {
+            isComplete: isStepComplete(instructorLessonStates, 'published'),
+            description: 'Publish lesson',
+          },
+        ]
+
         return (
           <TitleCard
             title={<Text message='getPublished.title' />}
             description={<Text message='getPublished.description' />}
+            intro={
+              <Progress 
+                total={size(checklistItems)}
+                complete={size(filter(checklistItems, 'isComplete'))}
+              />
+            }
           >
-            <Checklist items={[
-              {
-                isComplete: true,
-                description: 'Create instructor account',
-              },
-              {
-                isComplete: isString(instructor.slack_id),
-                description: 'Join egghead Slack',
-                moreInfoUrl: chatInfoUrl,
-              },
-              {
-                isComplete: isStepComplete(instructorLessonStates, 'claimed'),
-                description: 'Claim new lesson',
-                action: '/lessons/new',
-              },
-              {
-                isComplete: isStepComplete(instructorLessonStates, 'submitted'),
-                description: 'Submit rough draft',
-                moreInfoUrl: roughDraftInfoUrl,
-              },
-              {
-                isComplete: isString(instructor.gear_tracking_id),
-                description: 'Get gear',
-                moreInfoUrl: gearSetupInfoUrl,
-              },
-              {
-                isComplete: isStepComplete(instructorLessonStates, 'updated'),
-                description: 'Re-record with gear',
-                moreInfoUrl: roughDraftInfoUrl,
-              },
-              {
-                isComplete: isStepComplete(instructorLessonStates, 'approved'),
-                description: 'Iterate until approved',
-                moreInfoUrl: roughDraftInfoUrl,
-              },
-              {
-                isComplete: isStepComplete(instructorLessonStates, 'published'),
-                description: 'Publish lesson',
-              },
-            ]} />
+            <Checklist items={checklistItems} />
           </TitleCard>
         )
       }}

--- a/src/screens/Dashboard/components/GetPublishedCard/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/index.js
@@ -25,41 +25,41 @@ export default ({instructor}) => (
         const checklistItems = [
           {
             isComplete: true,
-            description: 'Create instructor account',
+            description: <Text message='getPublished.createInstructorAccount' />,
           },
           {
             isComplete: isString(instructor.slack_id),
-            description: 'Join egghead Slack',
+            description: <Text message='getPublished.joinSlack' />,
             moreInfoUrl: chatInfoUrl,
           },
           {
             isComplete: isStepComplete(instructorLessonStates, 'claimed'),
-            description: 'Claim new lesson',
+            description: <Text message='getPublished.claimLesson' />,
             action: '/lessons/new',
           },
           {
             isComplete: isStepComplete(instructorLessonStates, 'submitted'),
-            description: 'Submit rough draft',
+            description: <Text message='getPublished.submitRoughDraft' />,
             moreInfoUrl: roughDraftInfoUrl,
           },
           {
             isComplete: isString(instructor.gear_tracking_id),
-            description: 'Get gear',
+            description: <Text message='getPublished.getGear' />,
             moreInfoUrl: gearSetupInfoUrl,
           },
           {
             isComplete: isStepComplete(instructorLessonStates, 'updated'),
-            description: 'Re-record with gear',
+            description: <Text message='getPublished.recordWithGear' />,
             moreInfoUrl: roughDraftInfoUrl,
           },
           {
             isComplete: isStepComplete(instructorLessonStates, 'approved'),
-            description: 'Iterate until approved',
+            description: <Text message='getPublished.iterate' />,
             moreInfoUrl: roughDraftInfoUrl,
           },
           {
             isComplete: isStepComplete(instructorLessonStates, 'published'),
-            description: 'Publish lesson',
+            description: <Text message='getPublished.publish' />,
           },
         ]
 

--- a/src/screens/Dashboard/components/GetPublishedCard/index.js
+++ b/src/screens/Dashboard/components/GetPublishedCard/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {map, uniq, compact, isString} from 'lodash'
 import {Text} from 'react-localize'
+import {Maybe} from 'egghead-ui'
 import {chatInfoUrl, roughDraftInfoUrl, gearSetupInfoUrl} from 'utils/urls'
 import {hasUnlockedPublished} from 'utils/milestones'
 import createLessonsUrl from 'utils/createLessonsUrl'
@@ -9,9 +10,9 @@ import WrappedRequest from 'components/WrappedRequest'
 import isStepComplete from './utils/isStepComplete'
 import Checklist from './components/Checklist'
 
-export default ({instructor}) => hasUnlockedPublished(instructor.published_lessons)
-  ? null
-  : <WrappedRequest
+export default ({instructor}) => (
+  <Maybe condition={!hasUnlockedPublished(instructor.published_lessons)}>
+    <WrappedRequest
       url={createLessonsUrl({
         lessons_url: instructor.lessons_url
       })}
@@ -68,3 +69,5 @@ export default ({instructor}) => hasUnlockedPublished(instructor.published_lesso
         )
       }}
     </WrappedRequest>
+  </Maybe>
+)

--- a/src/screens/Dashboard/components/HelpCard/index.js
+++ b/src/screens/Dashboard/components/HelpCard/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import {map} from 'lodash'
-import {Button, Paragraph, List} from 'egghead-ui'
+import {Maybe, Button, Paragraph, List} from 'egghead-ui'
 import {Text} from 'react-localize'
 import {guideUrl, chatUrl, instructorsChatUrl} from 'utils/urls'
+import {hasUnlockedPublished} from 'utils/milestones'
 import TitleCard from 'components/TitleCard'
 import Anchor from 'components/Anchor'
 
@@ -24,8 +25,9 @@ const items=[
   },
 ]
 
-export default ({publishedLessons}) => publishedLessons === 0
-  ? <TitleCard
+export default ({publishedLessons}) => (
+  <Maybe condition={!hasUnlockedPublished(publishedLessons)}>
+    <TitleCard
       title={<Text message='help.title' />}
       description={<Text message='help.description' />}
     >
@@ -42,4 +44,5 @@ export default ({publishedLessons}) => publishedLessons === 0
         </div>
       ))} />
     </TitleCard>
-  : null
+  </Maybe>
+)

--- a/src/screens/Dashboard/index.js
+++ b/src/screens/Dashboard/index.js
@@ -13,10 +13,7 @@ export default ({instructor}) => hasUnlockedPublished(instructor.published_lesso
       <LayoutColumns 
         items={[
           <InstructorRevenueCard revenueUrl={instructor.revenue_url} />,
-          <InstructorStatsCard
-            publishedLessons={instructor.published_lessons}
-            publishedCourses={instructor.published_courses}
-          />,
+          <InstructorStatsCard instructor={instructor} />,
         ]}
         relativeSizes={[2, 1]}
       />

--- a/src/screens/Instructors/components/InstructorGroupsCard/components/InstructorList/components/InstructorListItem/index.js
+++ b/src/screens/Instructors/components/InstructorGroupsCard/components/InstructorList/components/InstructorListItem/index.js
@@ -1,68 +1,68 @@
 import React from 'react'
+import {map} from 'lodash'
 import {Link} from 'react-router-dom'
-import {Heading} from 'egghead-ui'
+import {Maybe, Heading} from 'egghead-ui'
 import {Text} from 'react-localize'
 import Avatar from 'components/Avatar'
 import LessonGroupsStat from './components/LessonGroupsStat'
 
-export default ({instructor}) => (
-  <div>
+export default ({instructor}) => {
 
-    <div className='flex items-center'>
+  const lessonGroupsStats = [
+    {
+      message: 'lessonGroups.inProgress.title' ,
+      count: instructor.claimed_lessons,
+    },
+    {
+      message: 'lessonGroups.inReview.title',
+      count: instructor.submitted_lessons,
+    },
+    {
+      message: 'lessonGroups.inQueue.title' ,
+      count: instructor.approved_lessons,
+    },
+    {
+      message: 'lessonGroups.published.title' ,
+      count: instructor.published_lessons,
+    },
+  ]
 
-      <div className='mr3'>
-        <Avatar
-          name={instructor.first_name}
-          url={instructor.avatar_url}
-        />
+  return (
+    <div>
+
+      <div className='flex items-center'>
+
+        <div className='mr3'>
+          <Avatar
+            name={instructor.first_name}
+            url={instructor.avatar_url}
+          />
+        </div>
+
+        <Link to={`/instructors/${instructor.slug}`}>
+          <Heading level='3'>
+            {instructor.full_name}
+          </Heading>
+        </Link>
+
       </div>
 
-      <Link to={`/instructors/${instructor.slug}`}>
-        <Heading level='3'>
-          {instructor.full_name}
-        </Heading>
-      </Link>
+      <section className='flex flex-wrap'>
+        {map(lessonGroupsStats, group => (
+          <Maybe 
+            key={group.message}
+            condition={Boolean(group.count)}
+          >
+            <div className='mt3 mr3'>
+              <LessonGroupsStat
+                label={<Text message={group.message} />}
+                count={group.count}
+              /> 
+            </div>
+          </Maybe>
+        ))}
+      </section>
 
     </div>
-
-    <section className="flex flex-wrap">
-      {instructor.claimed_lessons 
-        ? <div className='mt3 mr3'>
-            <LessonGroupsStat
-              label={<Text message='lessonGroups.inProgress.title' />}
-              count={instructor.claimed_lessons}
-            /> 
-          </div>
-        : null
-      }
-      {instructor.submitted_lessons
-        ? <div className='mt3 mr3'>
-            <LessonGroupsStat
-              label={<Text message='lessonGroups.inReview.title' />}
-              count={instructor.submitted_lessons}
-            /> 
-          </div>
-        : null
-      }
-      {instructor.approved_lessons
-        ? <div className='mt3 mr3'>
-            <LessonGroupsStat
-              label={<Text message='lessonGroups.inQueue.title' />}
-              count={instructor.approved_lessons}
-            /> 
-          </div>
-        : null
-      }
-      {instructor.published_lessons
-        ? <div className='mt3'>
-            <LessonGroupsStat
-              label={<Text message='lessonGroups.published.title' />}
-              count={instructor.published_lessons}
-            /> 
-          </div>
-        : null
-      }
-    </section>
-
-  </div>
-)
+  )
+}

--- a/src/screens/Instructors/screens/Instructor/index.js
+++ b/src/screens/Instructors/screens/Instructor/index.js
@@ -18,10 +18,7 @@ export default ({instructor}) => (
     />
     <LayoutColumns
       items={[
-        <InstructorStatsCard
-          publishedLessons={instructor.published_lessons}
-          publishedCourses={instructor.published_courses}
-        />,
+        <InstructorStatsCard instructor={instructor} />,
         <InstructorRevenueCard revenueUrl={instructor.revenue_url} />,
       ]}
       relativeSizes={[1, 2]}

--- a/src/utils/errorTracking/index.js
+++ b/src/utils/errorTracking/index.js
@@ -1,7 +1,7 @@
 import Honeybadger from 'honeybadger-js'
 import {honeybadgerKey} from 'utils/keys'
 
-export const initializeErrorTracking = (userId) => {
+export const initializeErrorTracking = (user) => {
   
   Honeybadger.configure({
     api_key: honeybadgerKey,
@@ -10,8 +10,10 @@ export const initializeErrorTracking = (userId) => {
 
   window.onerror = (message, url, line, column, error) => {
     Honeybadger.setContext({
-      userId,
-      precedingActions: JSON.parse(localStorage.getItem('precedingActions')),
+      name: user.name,
+      email: user.email,
+      userId: user.id,
+      instructorUrl: user.instructor_url,
     })
     Honeybadger.notify(error ? error : {
       name: message,

--- a/src/utils/localizationBundle/index.js
+++ b/src/utils/localizationBundle/index.js
@@ -38,6 +38,14 @@ export default {
   getPublished: {
     title: 'Get Published',
     description: 'Work with your mentor to complete these items so you can get published.',
+    createInstructorAccount: 'Create instructor account',
+    joinSlack: 'Join egghead Slack',
+    claimLesson: 'Claim new lesson' ,
+    submitRoughDraft: 'Submit rough draft',
+    getGear: 'Get gear',
+    recordWithGear: 'Re-record with gear',
+    iterate: 'Iterate until approved',
+    publish: 'Publish lesson',
   },
 
   help: {

--- a/src/utils/localizationBundle/index.js
+++ b/src/utils/localizationBundle/index.js
@@ -21,6 +21,10 @@ export default {
     next: 'Next',
   },
 
+  progress: {
+    completed: 'completed',
+  },
+
   navigation: {
     dashboard: 'Dashboard',
     lessons: 'Lessons',

--- a/src/utils/localizationBundle/index.js
+++ b/src/utils/localizationBundle/index.js
@@ -65,12 +65,6 @@ export default {
     },
   },
 
-  instructorStats: {
-    title: 'Instructor Stats',
-    lessons: '%s published',
-    courses: '%s published',
-  },
-
   instructorRevenue: {
     title: 'Instructor Revenue',
     subscriberMinutes: '%s minutes',

--- a/src/utils/localizationBundle/index.js
+++ b/src/utils/localizationBundle/index.js
@@ -36,7 +36,7 @@ export default {
   },
   
   getPublished: {
-    title: 'Get Published',
+    title: 'To Do',
     description: 'Work with your mentor to complete these items so you can get published.',
     createInstructorAccount: 'Create instructor account',
     joinSlack: 'Join egghead Slack',

--- a/yarn.lock
+++ b/yarn.lock
@@ -385,7 +385,7 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@6.17.0, babel-core@^6.11.4:
+babel-core@6.17.0, babel-core@^6.0.0:
   version "6.17.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.17.0.tgz#6c4576447df479e241e58c807e4bc7da4db7f425"
   dependencies:
@@ -411,7 +411,7 @@ babel-core@6.17.0, babel-core@^6.11.4:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-core@^6.0.0, babel-core@^6.23.0:
+babel-core@^6.11.4, babel-core@^6.23.0:
   version "6.23.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.23.1.tgz#c143cb621bb2f621710c220c5d579d15b8a442df"
   dependencies:
@@ -2139,9 +2139,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-egghead-ui@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/egghead-ui/-/egghead-ui-4.4.0.tgz#2f8d3028fd2f2375c8f79f56c4c286d03439cbb8"
+egghead-ui@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/egghead-ui/-/egghead-ui-4.6.1.tgz#033d17b11568e34b71703e05367e3830dc21a188"
   dependencies:
     "@kadira/storybook" "^2.5.2"
     axios "^0.15.3"


### PR DESCRIPTION
# Changes

- Update the get published checklist to latest mocks
- Update the lesson stats to latest mock; the course stats can use the same logic but is waiting on an API bug (https://github.com/eggheadio/egghead-instructor-center/issues/213)
- Fix honeybadger error
- Improve honeybadger reporting
- Use `Maybe` in place of null ternaries in JSX; recently added to `egghead-ui`

# Result For User

<img width="302" alt="todo-progress-3" src="https://cloud.githubusercontent.com/assets/5497885/24682003/dad777fc-1954-11e7-86f1-c94b1a45eafa.png">
<img width="302" alt="todo-progress-2" src="https://cloud.githubusercontent.com/assets/5497885/24682006/dadea4e6-1954-11e7-8ef0-5cf06a6f6c24.png">
<img width="300" alt="todo-progress-1" src="https://cloud.githubusercontent.com/assets/5497885/24682007/dadedfa6-1954-11e7-9a09-29b736320e1d.png">
<img width="386" alt="todo-full" src="https://cloud.githubusercontent.com/assets/5497885/24682005/dade1724-1954-11e7-98ea-a9e8a9c3a0d1.png">
<img width="389" alt="lesson-stats" src="https://cloud.githubusercontent.com/assets/5497885/24682004/dadbb97a-1954-11e7-8a66-d63ec6be4d13.png">

Note that the updates to the getting published todo list are mostly in line with the mocks, but there are still a couple small differences like the padding between list items (which will be addressed in https://github.com/eggheadio/egghead-ui/issues/94) and the icon types used (which will be addressed in https://github.com/eggheadio/egghead-instructor-center/issues/178).

---

![](https://media.giphy.com/media/PPXL9Lq60vNcc/giphy.gif)